### PR TITLE
fix login error message

### DIFF
--- a/src/Nowruz/modules/Auth/containers/signin/SignInForm/useSignInForm.tsx
+++ b/src/Nowruz/modules/Auth/containers/signin/SignInForm/useSignInForm.tsx
@@ -110,7 +110,7 @@ export const useSignInForm = () => {
       .then(onLoginSucceed)
       .then(registerPushNotifications)
       .catch((e) => {
-        if (e?.response?.data.error === 'Not matched') {
+        if (e?.response?.data.error) {
           setError('password', {
             type: 'manual',
             message: 'Username or password not matched',

--- a/src/Nowruz/pages/forget-password/email.tsx
+++ b/src/Nowruz/pages/forget-password/email.tsx
@@ -6,7 +6,7 @@ export const Email = () => {
   return (
     <div className={`pt-12 px-4  md:pt-24 form-container`}>
       <IntroHeader
-        title="Forgot Password?"
+        title="Forgot password?"
         description="No worries, we’ll send you reset instructions."
         logo={<FeaturedIcon src="/icons/nowruz/key-01.svg" />}
       />


### PR DESCRIPTION
if users enters less than 8 character password, login API returns an error different from 'not matched' which was not handled in UI