### PR TITLE
add a11y addon into storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cypress/videos/
 cypress/screenshots/
 cypress.env.json
 storybook-static
+node_modules/.package-lock.json

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@storybook/addon-onboarding',
     '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
     {
       name: '@storybook/addon-postcss',
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@babel/core": "^7.20.7",
         "@capacitor/assets": "^2.0.4",
         "@capacitor/cli": "^4.6.1",
+        "@storybook/addon-a11y": "^7.6.7",
         "@storybook/addon-essentials": "^7.5.0",
         "@storybook/addon-interactions": "^7.5.0",
         "@storybook/addon-links": "^7.5.0",
@@ -8303,6 +8304,33 @@
         "@stablelib/keyagreement": "^1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.6.7.tgz",
+      "integrity": "sha512-poT2oXIYDwLnhqn6g9ACTQ+7gi8QDHVlib4TQANdcozC/qYg+Bs6Pd99wT6rT4lrC/npVNTSKKwLw+3oXqlCxg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addon-highlight": "7.6.7",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/addon-highlight": {
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.6.7.tgz",
+      "integrity": "sha512-2F/tJdn45d4zrvf/cmE1vsczl99wK8+I+kkj0G7jLsrJR0w1zTgbgjy6T9j86HBTBvWcnysNFNIRWPAOh5Wdbw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/addon-actions": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@babel/core": "^7.20.7",
     "@capacitor/assets": "^2.0.4",
     "@capacitor/cli": "^4.6.1",
+    "@storybook/addon-a11y": "^7.6.7",
     "@storybook/addon-essentials": "^7.5.0",
     "@storybook/addon-interactions": "^7.5.0",
     "@storybook/addon-links": "^7.5.0",

--- a/src/Nowruz/modules/general/components/BackLink/index.tsx
+++ b/src/Nowruz/modules/general/components/BackLink/index.tsx
@@ -20,7 +20,7 @@ export const BackLink: React.FC<BackLinkProps> = (props) => {
     <Button
       color="secondary"
       variant="text"
-      startIcon={<img height={24} src="/icons/arrow-left.svg" />}
+      startIcon={<img height={24} src="/icons/arrow-left.svg" alt="back-button-icon" />}
       onClick={onClick}
       block={block}
       fullWidth

--- a/src/Nowruz/modules/general/components/SearchDropdown/index.tsx
+++ b/src/Nowruz/modules/general/components/SearchDropdown/index.tsx
@@ -77,7 +77,13 @@ export const SearchDropdown: React.FC<SelectProps> = ({
   return (
     <div className={`${css.container} ${className}`}>
       <div className={css.labelContainer}>
-        <label htmlFor={id} className={css.label} onClick={handleLabelClick} aria-describedby={id} id="searchDropdown">
+        <label
+          htmlFor={id}
+          className={css.label}
+          onClick={handleLabelClick}
+          aria-describedby={id}
+          id={`searchDropdown-${id}`}
+        >
           {label}
         </label>
       </div>
@@ -115,7 +121,7 @@ export const SearchDropdown: React.FC<SelectProps> = ({
             indicatorSeparator: () => ({ display: 'none' }),
           }}
           {...props}
-          aria-labelledby="searchDropdown"
+          aria-labelledby={`searchDropdown-${id}`}
         />
       ) : (
         <Select

--- a/src/Nowruz/modules/general/components/SearchDropdown/index.tsx
+++ b/src/Nowruz/modules/general/components/SearchDropdown/index.tsx
@@ -77,7 +77,7 @@ export const SearchDropdown: React.FC<SelectProps> = ({
   return (
     <div className={`${css.container} ${className}`}>
       <div className={css.labelContainer}>
-        <label htmlFor={id} className={css.label} onClick={handleLabelClick} aria-describedby={id}>
+        <label htmlFor={id} className={css.label} onClick={handleLabelClick} aria-describedby={id} id="searchDropdown">
           {label}
         </label>
       </div>
@@ -115,6 +115,7 @@ export const SearchDropdown: React.FC<SelectProps> = ({
             indicatorSeparator: () => ({ display: 'none' }),
           }}
           {...props}
+          aria-labelledby="searchDropdown"
         />
       ) : (
         <Select
@@ -150,6 +151,7 @@ export const SearchDropdown: React.FC<SelectProps> = ({
             indicatorSeparator: () => ({ display: 'none' }),
           }}
           {...props}
+          aria-labelledby="searchDropdown"
         />
       )}
       {errors &&

--- a/src/Nowruz/modules/general/components/iconDropDown/index.tsx
+++ b/src/Nowruz/modules/general/components/iconDropDown/index.tsx
@@ -26,7 +26,12 @@ export const IconDropDown: React.FC<IconDropDownProps> = (props) => {
 
   return (
     <div className="flex flex-col items-end relative">
-      <IconButton className={`${css.avatarBtn} ${open && `${css.avatarBtnOpen}`}`} disableRipple onClick={handleClick}>
+      <IconButton
+        className={`${css.avatarBtn} ${open && `${css.avatarBtnOpen}`}`}
+        disableRipple
+        onClick={handleClick}
+        aria-label="icon-button"
+      >
         <Avatar
           size={size}
           type={type}

--- a/src/stories/button.stories.tsx
+++ b/src/stories/button.stories.tsx
@@ -35,8 +35,8 @@ export const Icon = Template.bind({});
 Icon.args = {
   color: 'primary',
   variant: 'outlined',
-  startIcon: <img src="/icons/chevron-left.svg" width="15px" height="15px" />,
-  endIcon: <img src="/icons/eye-black.svg" width="15px" height="15px" />,
+  startIcon: <img src="/icons/chevron-left.svg" width="15px" height="15px" alt="icon-left" />,
+  endIcon: <img src="/icons/eye-black.svg" width="15px" height="15px" alt="icon-right" />,
 };
 Icon.parameters = {
   design: {


### PR DESCRIPTION
**Ticket:** [Add Accessibility Addon to Storybook](https://www.notion.so/socious/Add-Accessibility-Addon-to-Storybook-39a7cef6faae4761bef0e1fb6a36b58c?pvs=4)

**Description:**
- Added a11y add-on in the storybook so that we will be able to check locally the accessibility.
- Also addressed some of the common a11y violations we have right now in our components

**Media**
Accessibility addon:
<img width="1724" alt="Screenshot 2024-01-03 at 9 49 58 pm" src="https://github.com/socious-io/web-app-v2/assets/5590282/37e3907f-9fca-476b-b17c-cdd441fbc1ea">

Some _Violations_ that have been resolved:
<img width="1289" alt="Screenshot 2024-01-03 at 7 51 35 pm" src="https://github.com/socious-io/web-app-v2/assets/5590282/740d1944-cba1-4205-ad93-338902513115">
<img width="1265" alt="Screenshot 2024-01-03 at 7 54 02 pm" src="https://github.com/socious-io/web-app-v2/assets/5590282/b094d84f-ca1c-4bb6-90e8-79c1d7052d1b">
<img width="1022" alt="Screenshot 2024-01-03 at 9 25 37 pm" src="https://github.com/socious-io/web-app-v2/assets/5590282/a367eca9-f325-4c62-9e05-301808ab6018">

