### PR TITLE
chore: change the redirect page if user has not been registered

### DIFF
--- a/src/Nowruz/pages/oauth/google.tsx
+++ b/src/Nowruz/pages/oauth/google.tsx
@@ -27,7 +27,7 @@ export const GoogleOauth2 = () => {
     const path = await nonPermanentStorage.get('savedLocation');
     store.dispatch(setIdentityList(await identities()));
     const userProfile = await profile();
-    const userLandingPath = checkOnboardingMandatoryFields(userProfile) ? '/sign-up/user/welcome' : '/jobs';
+    const userLandingPath = checkOnboardingMandatoryFields(userProfile) ? '/sign-up/user/complete' : '/jobs';
     navigate(path ? path : userLandingPath);
     return loginResp;
   }


### PR DESCRIPTION
**Ticket:** [Login with the Google account that is not registered on Socious, should proceed to talent sign-up](https://www.notion.so/socious/Login-with-the-Google-account-that-is-not-registered-on-Socious-should-proceed-to-talent-sign-up-4fff1fee9e784a399dbe1ceb3b77755b?pvs=4)

**Description:**
- Change the redirect path once successfully authorised from Google

**Media:**

https://github.com/socious-io/web-app-v2/assets/5590282/8d8ee7ca-133f-4017-bf4a-05be2daed26a

