### PR TITLE
fix: rejected by qa about tab fixes

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -2950,16 +2950,16 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
-    "node_modules/@esbuild/linux-x64": {
+    "node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ],
       "engines": {
         "node": ">=12"
@@ -5792,35 +5792,16 @@
         "@parcel/watcher-win32-x64": "2.3.0"
       }
     },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
+    "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.3.0.tgz",
-      "integrity": "sha512-P7Wo91lKSeSgMTtG7CnBS6WrA5otr1K7shhSjKHNePVmfBHDoAOHYRXgUmhiNfbcGk0uMCHVcdbfxtuiZCHVow==",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.3.0.tgz",
+      "integrity": "sha512-mKY+oijI4ahBMc/GygVGvEdOq0L4DxhYgwQqYAz/7yPzuGi79oXrZG52WdpGA1wLBPrYb0T8uBaGFo7I6rvSKw==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "optional": true,
       "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.3.0.tgz",
-      "integrity": "sha512-+kiRE1JIq8QdxzwoYY+wzBs9YbJ34guBweTK8nlzLKimn5EQ2b2FSC+tAOpq302BuIMjyuUGvBiUhEcLIGMQ5g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
+        "darwin"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -8493,33 +8474,17 @@
         }
       }
     },
-    "node_modules/@swc/core-linux-x64-gnu": {
+    "node_modules/@swc/core-darwin-arm64": {
       "version": "1.3.102",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.102.tgz",
-      "integrity": "sha512-dFvnhpI478svQSxqISMt00MKTDS0e4YtIr+ioZDG/uJ/q+RpcNy3QI2KMm05Fsc8Y0d4krVtvCKWgfUMsJZXAg==",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.102.tgz",
+      "integrity": "sha512-CJDxA5Wd2cUMULj3bjx4GEoiYyyiyL8oIOu4Nhrs9X+tlg8DnkCm4nI57RJGP8Mf6BaXPIJkHX8yjcefK2RlDA==",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "dev": true,
       "optional": true,
       "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.102",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.102.tgz",
-      "integrity": "sha512-+a0M3CvjeIRNA/jTCzWEDh2V+mhKGvLreHOL7J97oULZy5yg4gf7h8lQX9J8t9QLbf6fsk+0F8bVH1Ie/PbXjA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
+        "darwin"
       ],
       "engines": {
         "node": ">=10"
@@ -16504,6 +16469,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/src/Nowruz/modules/general/components/countryFlag/countryFlag.module.scss
+++ b/src/Nowruz/modules/general/components/countryFlag/countryFlag.module.scss
@@ -1,0 +1,6 @@
+@import 'src/components/_primitives.scss';
+
+.rounded {
+  border-radius: 100%;
+  height: 80%;
+}

--- a/src/Nowruz/modules/general/components/countryFlag/index.tsx
+++ b/src/Nowruz/modules/general/components/countryFlag/index.tsx
@@ -1,4 +1,7 @@
 import * as Flags from 'country-flag-icons/react/1x1';
+import React from 'react';
+
+import css from './countryFlag.module.scss';
 
 interface CountryFlagProps {
   countryCode: string;
@@ -6,5 +9,5 @@ interface CountryFlagProps {
 
 export const CountryFlag: React.FC<CountryFlagProps> = ({ countryCode }) => {
   const FlagComponent = Flags[countryCode.toUpperCase() as keyof typeof Flags];
-  return <FlagComponent className="w-6 h-5 rounded-3xl" />;
+  return <FlagComponent className={`w-5 ${css.rounded}`} />;
 };

--- a/src/Nowruz/modules/general/utils/index.ts
+++ b/src/Nowruz/modules/general/utils/index.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { isTouchDevice } from 'src/core/device-type-detector';
+
+export const useSeeMore = (copy: string) => {
+  const [seeMore, setSeeMore] = useState(false);
+  const [copyProccessed, setCopyProccessed] = useState(copy);
+
+  const truncateString = () => {
+    const len = copy?.length || 0;
+    const maxLen = isTouchDevice() ? 160 : 360;
+
+    if (copy && len <= maxLen) {
+      setCopyProccessed(copy);
+      setSeeMore(false);
+      return;
+    }
+
+    if (copy && len > maxLen) {
+      let truncated = copy?.slice(0, maxLen);
+      if (truncated.charAt(truncated.length - 1) !== ' ') {
+        const idx = truncated.lastIndexOf(' ');
+        truncated = truncated.slice(0, idx);
+      }
+      setCopyProccessed(truncated.concat('...'));
+      setSeeMore(true);
+    }
+  };
+
+  const handleSeeMore = () => {
+    setCopyProccessed(copy);
+    setSeeMore(false);
+  };
+
+  useEffect(() => {
+    truncateString();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [copy]);
+
+  return {
+    data: { seeMore, copyProccessed },
+    operations: { handleSeeMore },
+  };
+};

--- a/src/Nowruz/modules/userProfile/components/about/about.module.scss
+++ b/src/Nowruz/modules/userProfile/components/about/about.module.scss
@@ -30,3 +30,17 @@
 .addBtn:hover {
   background-color: none;
 }
+
+.mission {
+  p {
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5rem;
+    color: $color-grey-600;
+  }
+  .seeMoreBtn {
+    color: $color-primary-700;
+    font-weight: 500;
+    margin-left: 0.5rem;
+  }
+}

--- a/src/Nowruz/modules/userProfile/components/about/certificate/certificates.tsx
+++ b/src/Nowruz/modules/userProfile/components/about/certificate/certificates.tsx
@@ -1,3 +1,4 @@
+import variables from 'src/components/_exports.module.scss';
 import { CertificateMeta } from 'src/core/api/additionals/additionals.types';
 import { Icon } from 'src/Nowruz/general/Icon';
 import { Button } from 'src/Nowruz/modules/general/components/Button';
@@ -26,7 +27,7 @@ export const Certificates = () => {
         <div className={css.title}>Certificates</div>
         {myProfile && (
           <Button variant="text" color="primary" className={css.addBtn} onClick={handleAdd}>
-            <Icon name="plus" fontSize={20} />
+            <Icon name="plus" fontSize={20} color={variables.color_primary_700} />
             Add certificate
           </Button>
         )}

--- a/src/Nowruz/modules/userProfile/components/about/education/educations.tsx
+++ b/src/Nowruz/modules/userProfile/components/about/education/educations.tsx
@@ -1,3 +1,4 @@
+import variables from 'src/components/_exports.module.scss';
 import { EducationMeta } from 'src/core/api/additionals/additionals.types';
 import { Icon } from 'src/Nowruz/general/Icon';
 import { Button } from 'src/Nowruz/modules/general/components/Button';
@@ -29,7 +30,7 @@ export const Educations = () => {
         <div className={css.title}>Educations</div>
         {myProfile && (
           <Button variant="text" color="primary" className={css.addBtn} onClick={handleAdd}>
-            <Icon name="plus" fontSize={20} />
+            <Icon name="plus" fontSize={20} color={variables.color_primary_700} />
             Add education
           </Button>
         )}

--- a/src/Nowruz/modules/userProfile/components/about/recommendaion/recommendation.tsx
+++ b/src/Nowruz/modules/userProfile/components/about/recommendaion/recommendation.tsx
@@ -1,3 +1,4 @@
+import variables from 'src/components/_exports.module.scss';
 import { RecommendationMeta } from 'src/core/api/additionals/additionals.types';
 import { Icon } from 'src/Nowruz/general/Icon';
 import { Button } from 'src/Nowruz/modules/general/components/Button';
@@ -19,7 +20,7 @@ export const Recommendation = () => {
             className={css.addBtn}
             // onClick={handleAdd}
           >
-            <Icon name="plus" fontSize={20} />
+            <Icon name="plus" fontSize={20} color={variables.color_primary_700} />
             Ask for recommendation
           </Button>
         )}

--- a/src/Nowruz/modules/userProfile/components/about/summary.tsx
+++ b/src/Nowruz/modules/userProfile/components/about/summary.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import variables from 'src/components/_exports.module.scss';
 import { CurrentIdentity, Organization, User } from 'src/core/api';
 import { IconButton } from 'src/Nowruz/modules/general/components/iconButton';
+import { useSeeMore } from 'src/Nowruz/modules/general/utils';
 import { EditSummary } from 'src/Nowruz/modules/userProfile/containers/editSummery';
 import { RootState } from 'src/store';
 
@@ -15,6 +16,12 @@ export const Summary = () => {
   const currentIdentity = useSelector<RootState, CurrentIdentity | undefined>((state) => {
     return state.identity.entities.find((identity) => identity.current);
   });
+
+  const {
+    data: { seeMore, copyProccessed },
+    operations: { handleSeeMore },
+  } = useSeeMore(identity?.mission ?? '');
+
   const myProfile = currentIdentity?.id === identity?.id;
   const type = currentIdentity?.type;
   const [openEditModal, setOpenEditModal] = useState(false);
@@ -35,7 +42,16 @@ export const Summary = () => {
             />
           )}
         </div>
-        <div>{identity?.mission}</div>
+        <div className={css.mission}>
+          <p>
+            {copyProccessed}
+            {seeMore && (
+              <span className={css.seeMoreBtn} onClick={handleSeeMore}>
+                see more
+              </span>
+            )}
+          </p>
+        </div>
       </div>
       <EditSummary open={openEditModal} handleClose={() => setOpenEditModal(false)} type={type} />
     </>

--- a/src/Nowruz/modules/userProfile/components/location/index.tsx
+++ b/src/Nowruz/modules/userProfile/components/location/index.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@mui/material';
 import React from 'react';
 import { COUNTRIES_DICT } from 'src/constants/COUNTRIES';
-import { Icon } from 'src/Nowruz/general/Icon';
 import { CountryFlag } from 'src/Nowruz/modules/general/components/countryFlag';
 
 export interface LocationProps {
@@ -10,7 +9,7 @@ export interface LocationProps {
   iconName?: string;
 }
 export const Location: React.FC<LocationProps> = (props) => {
-  const { country, city, iconName } = props;
+  const { country, city } = props;
   function getCountryName(shortname?: keyof typeof COUNTRIES_DICT | undefined) {
     if (shortname && COUNTRIES_DICT[shortname]) {
       return COUNTRIES_DICT[shortname];
@@ -27,8 +26,7 @@ export const Location: React.FC<LocationProps> = (props) => {
         Location
       </Typography>
       <div className="flex gap-2 items-center">
-        {/* <CountryFlag countryCode={country || ''} /> */}
-        <Icon fontSize={20} name="marker-pin-02" className="text-Gray-light-mode-700" />
+        <CountryFlag countryCode={country || ''} />
         <Typography variant="h6" className="text-Gray-light-mode-700">
           {address}
         </Typography>

--- a/src/Nowruz/modules/userProfile/components/mainInfo/index.tsx
+++ b/src/Nowruz/modules/userProfile/components/mainInfo/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import variables from 'src/components/_exports.module.scss';
 import { socialCausesToCategory } from 'src/core/adaptors';
 import { CurrentIdentity, Organization, User } from 'src/core/api';
+import { Icon } from 'src/Nowruz/general/Icon';
 import { ChipList } from 'src/Nowruz/modules/general/components/chipList';
 import { Link } from 'src/Nowruz/modules/general/components/link';
 import { RootState } from 'src/store';
@@ -23,6 +24,10 @@ export const MainInfo = () => {
   });
   const myProfile = currentIdentity?.id === identity?.id;
   const type = currentIdentity?.type;
+  const org = identity as Organization;
+  const user = identity as User;
+
+  console.log('test log org', org);
 
   const socialCauses = socialCausesToCategory(identity?.social_causes).map((item) => item.label);
   const bioJSX = (
@@ -30,6 +35,22 @@ export const MainInfo = () => {
       <Typography className={css.textMd}>{identity?.bio}</Typography>
     </div>
   );
+
+  const renderData = (title: string, iconName: string, value: string) => {
+    return (
+      <div className="flex flex-col gap-2">
+        <Typography variant="subtitle1" className="text-Gray-light-mode-600">
+          {title}
+        </Typography>
+        <div className="flex gap-2">
+          <Icon name={iconName} fontSize={20} color={variables.color_grey_500} />
+          <Typography variant="h6" className="text-Gray-light-mode-700">
+            {value}
+          </Typography>
+        </div>
+      </div>
+    );
+  };
 
   const connectionJSX = (
     <div className="flex gap-2">
@@ -49,8 +70,10 @@ export const MainInfo = () => {
         fontColor={variables.color_primary_700}
       />
       <Location country={identity?.country} city={identity?.city} iconName={identity?.country} />
-      {type === 'users' && (identity as User).languages && <LanguageJSX items={(identity as User).languages || []} />}
-      {(identity as Organization).website && <Website website={(identity as Organization).website ?? ''} />}
+      {type === 'users' && user.languages && <LanguageJSX items={user.languages || []} />}
+      {org.industry && renderData('Industry', 'globe-04', org.industry)}
+      {org.size && renderData('Size', 'users-01', org.size)}
+      {org.website && <Website website={org.website ?? ''} />}
     </div>
   );
 };

--- a/src/Nowruz/modules/userProfile/components/mainInfo/index.tsx
+++ b/src/Nowruz/modules/userProfile/components/mainInfo/index.tsx
@@ -11,11 +11,13 @@ import css from './mainInfo.module.scss';
 import { Impact } from '../impact';
 import { LanguageJSX } from '../languages';
 import { Location } from '../location';
+import { Website } from '../website';
 
 export const MainInfo = () => {
   const identity = useSelector<RootState, User | Organization | undefined>((state) => {
     return state.profile.identity;
   });
+
   const currentIdentity = useSelector<RootState, CurrentIdentity | undefined>((state) => {
     return state.identity.entities.find((identity) => identity.current);
   });
@@ -25,9 +27,7 @@ export const MainInfo = () => {
   const socialCauses = socialCausesToCategory(identity?.social_causes).map((item) => item.label);
   const bioJSX = (
     <div>
-      <Typography className={css.textMd} color={variables.color_gray_700}>
-        {identity?.bio}
-      </Typography>
+      <Typography className={css.textMd}>{identity?.bio}</Typography>
     </div>
   );
 
@@ -49,7 +49,8 @@ export const MainInfo = () => {
         fontColor={variables.color_primary_700}
       />
       <Location country={identity?.country} city={identity?.city} iconName={identity?.country} />
-      {type === 'users' && (identity as User).languages && <LanguageJSX items={(identity as User).languages} />}
+      {type === 'users' && (identity as User).languages && <LanguageJSX items={(identity as User).languages || []} />}
+      {(identity as Organization).website && <Website website={(identity as Organization).website ?? ''} />}
     </div>
   );
 };

--- a/src/Nowruz/modules/userProfile/components/mainInfo/mainInfo.module.scss
+++ b/src/Nowruz/modules/userProfile/components/mainInfo/mainInfo.module.scss
@@ -1,16 +1,19 @@
+@import 'src/components/_primitives.scss';
+
 .textMd {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 400;
-  line-height: 24px;
+  line-height: 1.5rem;
   letter-spacing: 0em;
   text-align: left;
+  color: $color-grey-700;
 }
 
 .textSM {
   font-family: Inter;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
-  line-height: 20px;
+  line-height: 1.25rem;
   letter-spacing: 0em;
   text-align: left;
 }

--- a/src/Nowruz/modules/userProfile/components/profileHeader/desktopHeader.tsx
+++ b/src/Nowruz/modules/userProfile/components/profileHeader/desktopHeader.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import variables from 'src/components/_exports.module.scss';
 import { ConnectStatus, Organization, User } from 'src/core/api';
-import { getIdentityMeta } from 'src/core/utils';
 import { Icon } from 'src/Nowruz/general/Icon';
 import { AvatarProfile } from 'src/Nowruz/modules/general/components/avatarProfile';
 import { Button } from 'src/Nowruz/modules/general/components/Button';
+import { Chip } from 'src/Nowruz/modules/general/components/Chip';
 import { Dot } from 'src/Nowruz/modules/general/components/dot';
 import { IconButton } from 'src/Nowruz/modules/general/components/iconButton';
 
@@ -28,7 +28,12 @@ export const DesktopHeader: React.FC<DesktopHeaderProps> = ({
   handleOpenEditAvatar,
   type,
 }) => {
-  const { profileImage, name, username } = getIdentityMeta(identity);
+  const profileImage = type === 'users' ? (identity as User).avatar : (identity as Organization).image;
+  const name =
+    type === 'users'
+      ? `${(identity as User).first_name} ${(identity as User).last_name}`
+      : (identity as Organization).name;
+  const username = type === 'users' ? `@${(identity as User).username}` : `@${(identity as Organization).shortname}`;
 
   return (
     <div className="hidden md:block">
@@ -45,16 +50,22 @@ export const DesktopHeader: React.FC<DesktopHeaderProps> = ({
           <div className="text-base font-normal text-Gray-light-mode-500">{username}</div>
         </div>
         {type === 'users' && (identity as User).open_to_work && (
-          <div className={css.status}>
-            <Dot color={variables.color_success_500} size="small" shadow={false} />
-            <span className={css.statusText}>Available for work</span>
-          </div>
+          <Chip
+            label="Available for work"
+            size="lg"
+            theme="secondary"
+            startIcon={<Dot color={variables.color_success_500} size="small" shadow={false} />}
+            shape="sharp"
+          />
         )}
         {type === 'organizations' && (identity as Organization).hiring && (
-          <div className={css.status}>
-            <Dot color={variables.color_success_500} size="small" shadow={false} />
-            <span className={css.statusText}>Hiring</span>
-          </div>
+          <Chip
+            label="Hiring"
+            size="lg"
+            theme="secondary"
+            startIcon={<Dot color={variables.color_success_500} size="small" shadow={false} />}
+            shape="sharp"
+          />
         )}
         {myProfile && (
           <IconButton

--- a/src/Nowruz/modules/userProfile/components/profileHeader/profileHeader.module.scss
+++ b/src/Nowruz/modules/userProfile/components/profileHeader/profileHeader.module.scss
@@ -84,9 +84,8 @@
 }
 
 .status {
-  width: 153px;
   height: 28px;
-  padding: 4px, 10px, 4px, 10px;
+  padding: 4px 10px 4px 10px;
   border: 1px solid $color-grey-300;
   border-radius: 8px;
   gap: 6px;

--- a/src/Nowruz/modules/userProfile/components/website/index.tsx
+++ b/src/Nowruz/modules/userProfile/components/website/index.tsx
@@ -1,0 +1,27 @@
+import { Typography } from '@mui/material';
+import React from 'react';
+import variables from 'src/components/_exports.module.scss';
+import { Icon } from 'src/Nowruz/general/Icon';
+import { Link } from 'src/Nowruz/modules/general/components/link';
+
+import css from './website.module.scss';
+
+export interface WebsiteProps {
+  website: string;
+}
+export const Website: React.FC<WebsiteProps> = ({ website }) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <Typography variant="subtitle1" className="text-Gray-light-mode-600">
+        Website
+      </Typography>
+
+      <div className="flex gap-2 items-center">
+        <Typography variant="h6">
+          <Link href={website} label={website} color={variables.color_primary_700} customStyle={css.link} />
+        </Typography>
+        <Icon name="arrow-up-right" fontSize={20} color={variables.color_primary_700} />
+      </div>
+    </div>
+  );
+};

--- a/src/Nowruz/modules/userProfile/components/website/website.module.scss
+++ b/src/Nowruz/modules/userProfile/components/website/website.module.scss
@@ -1,0 +1,6 @@
+@import 'src/components/_primitives.scss';
+
+.link {
+  font-size: 1rem;
+  color: $color-primary-700;
+}

--- a/src/Nowruz/pages/orgProfile/index.tsx
+++ b/src/Nowruz/pages/orgProfile/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { HorizontalTabs } from 'src/Nowruz/modules/general/components/horizontalTabs';
 import { MainInfo } from 'src/Nowruz/modules/userProfile/components/mainInfo';
 import { ProfileHeader } from 'src/Nowruz/modules/userProfile/components/profileHeader';

--- a/src/stories/chip.stories.tsx
+++ b/src/stories/chip.stories.tsx
@@ -7,7 +7,7 @@ export default {
   component: Chip,
 } as Meta;
 
-const Template: Story = (args) => <Chip {...args} />;
+const Template: Story = (args) => <Chip size="md" {...args} />;
 
 export const PrimaryChip = Template.bind({});
 PrimaryChip.args = {


### PR DESCRIPTION
### Ticket: [OP. My profile: about tab (excluding all other tabs)](https://www.notion.so/socious/OP-My-profile-about-tab-excluding-all-other-tabs-687bda2240df478780746abdb169b333?pvs=4)

### Criteria:
- [x]  1. In Figma the color of the organization description(under the logo) is Gray
- [x]  2. The location icon in Figma is different
- [x]  3. In Figma the color of the text in Summary is different
- [x]  4. In Figma the color of the “**+**” icon next to the “Ask for recommendation” is different
- [x]  5. In Figma there is a link “see more” for the Summary
- [x]  6. The Width of “Hiring” is smaller in Figma
- [x]  7. The website section is missing. I see that in V2 for example Socious has data for the website address

### Media:

https://github.com/socious-io/web-app-v2/assets/5590282/2c1cd651-f987-4c5d-bf28-c20b6bc19f9a

