### PR TITLE
chore: remove pre filled username

### DIFF
--- a/src/Nowruz/modules/Auth/containers/signup/UserDetails/index.tsx
+++ b/src/Nowruz/modules/Auth/containers/signup/UserDetails/index.tsx
@@ -5,7 +5,7 @@ import { Input } from 'src/Nowruz/modules/general/components/input/input';
 import { useUserDetails } from './useUserDetails';
 export const UserDetails = () => {
   const { register, handleSubmit, onSubmit, errors, isUsernameValid, isFormValid, currentProfile } = useUserDetails();
-  const { last_name, first_name, username } = currentProfile.current;
+  const { last_name, first_name } = currentProfile.current;
 
   return (
     <>
@@ -46,7 +46,6 @@ export const UserDetails = () => {
               },
             ]}
             // prefix="socious.io/"
-            defaultValue={username}
             isValid={isUsernameValid}
             errors={errors['username']?.message ? [errors['username']?.message.toString()] : undefined}
           />


### PR DESCRIPTION
**Ticket:** [Filled username in sign-up screen: Username is unavailable](https://www.notion.so/socious/Filled-username-in-sign-up-screen-Username-is-unavailable-8c94c66a338f4db0bf6055d04111b79a?pvs=4)

**Description:**
- Remove the prefilled username if accounts are using gmail


https://github.com/socious-io/web-app-v2/assets/5590282/780d1a32-3ff9-461f-86e5-46690eff50a2

