### PR TITLE
Updated edit org component to make size editable

### DIFF
--- a/src/Nowruz/modules/userProfile/components/mainInfo/index.tsx
+++ b/src/Nowruz/modules/userProfile/components/mainInfo/index.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
 import { useSelector } from 'react-redux';
 import variables from 'src/components/_exports.module.scss';
+import { ORGANIZATION_SIZE } from 'src/constants/ORGANIZATION_SIZE';
 import { socialCausesToCategory } from 'src/core/adaptors';
 import { CurrentIdentity, Organization, User } from 'src/core/api';
 import { Icon } from 'src/Nowruz/general/Icon';
@@ -13,7 +14,6 @@ import { Impact } from '../impact';
 import { LanguageJSX } from '../languages';
 import { Location } from '../location';
 import { Website } from '../website';
-import { ORGANIZATION_SIZE } from 'src/constants/ORGANIZATION_SIZE';
 
 export const MainInfo = () => {
   const identity = useSelector<RootState, User | Organization | undefined>((state) => {
@@ -72,7 +72,7 @@ export const MainInfo = () => {
       {type === 'users' && user.languages && <LanguageJSX items={user.languages || []} />}
       {org.industry && renderData('Industry', 'globe-04', org.industry)}
       {size && renderData('Size', 'users-01', size)}
-      {org.website && <Website website={org.website ?? ''} />}
+      {org.website && <Website url={org.website ?? ''} />}
     </div>
   );
 };

--- a/src/Nowruz/modules/userProfile/containers/editInfoOrg/index.tsx
+++ b/src/Nowruz/modules/userProfile/containers/editInfoOrg/index.tsx
@@ -21,7 +21,6 @@ export const EditInfoOrgModal: React.FC<EditInfoOrgProps> = ({ open, handleClose
     onSelectCity,
     city,
     socialCauses,
-    // setSocialCauses,
     changeSocialCauses,
     socialCauseItems,
     searchIndustries,
@@ -32,6 +31,9 @@ export const EditInfoOrgModal: React.FC<EditInfoOrgProps> = ({ open, handleClose
     summary,
     handleChangeSummary,
     letterCount,
+    size,
+    sizeOptions,
+    onSelectSize,
   } = useEditInfoOrg(handleClose);
   const modalContent = (
     <form className={css.editInfoModal}>
@@ -96,6 +98,20 @@ export const EditInfoOrgModal: React.FC<EditInfoOrgProps> = ({ open, handleClose
           onSelectIndustry(value);
         }}
         errors={errors['industry']?.label?.message ? [errors['industry'].label.message.toString()] : undefined}
+      />
+      <SearchDropdown
+        required
+        id="organization-size"
+        label="Organization size*"
+        value={size}
+        options={sizeOptions}
+        className="flex-1"
+        hasDropdownIcon
+        onChange={(value) => {
+          onSelectSize(value);
+        }}
+        isSearchable
+        errors={errors['size']?.label?.message ? [errors['size'].label.message.toString()] : undefined}
       />
       <div className="w-full h-full flex flex-col gap-[6px]">
         <Input


### PR DESCRIPTION
This PR is related to this ticket, item 8
https://www.notion.so/socious/Nowruz-Other-org-s-profile-About-tab-excluding-all-other-tabs-e659494dfdf24a9bb36abe8c8707ea39

After checking the code realized that data can be displayed in the profile properly, but since the fields are null, nothing is displayed. To fix the issue checked the 'update component' and added company size field to 'update form', so this field could be modified and then displayed in the profile