### PR TITLE
Fix/Claim-User-Profile

### DIFF
--- a/src/Nowruz/modules/userProfile/components/about/experience/experience.tsx
+++ b/src/Nowruz/modules/userProfile/components/about/experience/experience.tsx
@@ -87,7 +87,7 @@ export const Experiences: React.FC<ExperienceProps> = ({ handleOpenVerifyModal }
                     disabled={!!disabledClaims[item.credential.id]}
                     className={css.addBtn}
                     key={item.credential.id}
-                    onClick={userVerified ? () => handleOpenClaimModal(item.id) : handleOpenVerifyModal}
+                    onClick={userVerified ? () => handleOpenClaimModal(item.credential?.id) : handleOpenVerifyModal}
                   >
                     Claim
                   </Button>


### PR DESCRIPTION
**FIX:**
- `credential.id` instead of `experience.id` in claiming in the user profile section