### PR TITLE
TAS-1448/Fix-Text-Button

### DIFF
--- a/src/Nowruz/modules/settings/components/leaveDeleteMember/index.tsx
+++ b/src/Nowruz/modules/settings/components/leaveDeleteMember/index.tsx
@@ -30,7 +30,7 @@ const LeaveDeleteMember: React.FC<LeaveDeleteMemberProps> = ({
         {!!buttons.length && (
           <div className="w-full flex flex-col-reverse md:flex-row items-center justify-end gap-3 mt-9">
             {buttons.map((button, index) => (
-              <Button key={index} {...button} className="w-full md:w-auto" />
+              <Button key={index} {...button} customStyle="w-full md:w-auto" />
             ))}
           </div>
         )}


### PR DESCRIPTION
**FIX:**
- camel case instead of upper case in button issue related to overwriting `classname`