### PR TITLE
Tas 2071/Fix-Submit-Success-Dispute

### DIFF
--- a/src/Nowruz/modules/contract/components/initiateDisputeModal/successInitiateDispute/index.tsx
+++ b/src/Nowruz/modules/contract/components/initiateDisputeModal/successInitiateDispute/index.tsx
@@ -1,6 +1,8 @@
+import { Slide, SlideProps } from '@mui/material';
 import React from 'react';
+import { isTouchDevice } from 'src/core/device-type-detector';
 import { FeaturedIconOutlined } from 'src/Nowruz/modules/general/components/featuredIconOutlined';
-import { Modal } from 'src/Nowruz/modules/general/components/modal';
+import CustomSnackbar from 'src/Nowruz/modules/general/components/Snackbar';
 
 import { SuccessInitiateDisputeProps } from './index.types';
 
@@ -11,37 +13,38 @@ const SuccessInitiateDispute: React.FC<SuccessInitiateDisputeProps> = ({
   respondentName,
   respondDate,
 }) => {
-  const headerJSX = (
-    <div className="flex flex-col md:flex-row gap-2">
-      <FeaturedIconOutlined iconName="check-circle" theme="success" size="md" />
-      <div className="flex flex-col text-sm font-semibold text-Gray-light-mode-900 md:pr-12 md:pl-0.5">
-        Dispute submitted successfully
-        <span className="font-normal text-sm leading-5 text-Gray-light-mode-500">
-          Thank you for submitting your dispute (Dispute ID #{disputeId})
-        </span>
-      </div>
-    </div>
-  );
+  const isMobile = isTouchDevice();
+  const SlideTransition = (props: SlideProps) => <Slide {...props} direction={isMobile ? 'up' : 'left'} />;
 
   return (
-    <Modal
+    <CustomSnackbar
       open={open}
-      handleClose={handleClose}
-      title={headerJSX}
-      customStyle="max-w-[400px]"
-      mobileCentered
-      headerDivider={false}
-      contentClassName="px-6 pb-6 md:px-12"
+      onClose={handleClose}
+      TransitionComponent={SlideTransition}
+      containerClassName="flex-nowrap !items-start max-w-[400px]"
+      contentClassName="md:!items-start"
+      icon={<FeaturedIconOutlined iconName="check-circle" size="md" theme="success" />}
+      anchorOrigin={isMobile ? { vertical: 'bottom', horizontal: 'center' } : { vertical: 'top', horizontal: 'right' }}
     >
-      <div className="text-sm flex flex-col gap-4 leading-5 md:px-6 text-Gray-light-mode-700">
-        <p>
-          <span className="font-semibold text-Brand-700">{respondentName} </span>
-          has been notified of your dispute and has until {respondDate} to respond. You will receive a notification once
-          they has provided their response or if any further action is required from you.
-        </p>
-        <p>In the meantime, you can track the progress of your dispute in this section of your contracts.</p>
+      <div className="flex flex-col gap-4 pb-2 px-2 md:py-2 md:px-0">
+        <div className="flex flex-col md:flex-row gap-2">
+          <div className="flex flex-col text-sm font-semibold text-Gray-light-mode-900">
+            Dispute submitted successfully
+            <span className="font-normal text-sm leading-5 text-Gray-light-mode-500">
+              Thank you for submitting your dispute (Dispute ID #{disputeId})
+            </span>
+          </div>
+        </div>
+        <div className="text-sm flex flex-col gap-4 leading-5 text-Gray-light-mode-700">
+          <p>
+            <span className="font-semibold text-Brand-700">{respondentName} </span>
+            has been notified of your dispute and has until {respondDate} to respond. You will receive a notification
+            once they has provided their response or if any further action is required from you.
+          </p>
+          <p>In the meantime, you can track the progress of your dispute in this section of your contracts.</p>
+        </div>
       </div>
-    </Modal>
+    </CustomSnackbar>
   );
 };
 

--- a/src/Nowruz/modules/contract/components/respondDisputeModal/successRespondDispute/index.tsx
+++ b/src/Nowruz/modules/contract/components/respondDisputeModal/successRespondDispute/index.tsx
@@ -1,6 +1,8 @@
+import { Slide, SlideProps } from '@mui/material';
 import React from 'react';
+import { isTouchDevice } from 'src/core/device-type-detector';
 import { FeaturedIconOutlined } from 'src/Nowruz/modules/general/components/featuredIconOutlined';
-import { Modal } from 'src/Nowruz/modules/general/components/modal';
+import CustomSnackbar from 'src/Nowruz/modules/general/components/Snackbar';
 
 import { SuccessRespondDisputeProps } from './index.types';
 
@@ -10,34 +12,35 @@ const SuccessRespondDispute: React.FC<SuccessRespondDisputeProps> = ({
   disputeId,
   claimantName,
 }) => {
-  const headerJSX = (
-    <div className="flex flex-col md:flex-row gap-2">
-      <FeaturedIconOutlined iconName="check-circle" theme="success" size="md" />
-      <div className="flex flex-col text-sm font-semibold text-Gray-light-mode-900 md:pr-12 md:pl-0.5">
-        Response submitted successfully
-        <span className="font-normal text-sm leading-5 text-Gray-light-mode-500">
-          Thank you for submitting your response to the dispute (Dispute ID #{disputeId}). Your response has been
-          successfully recorded and will be reviewed by the assigned jurors.
-        </span>
-      </div>
-    </div>
-  );
+  const isMobile = isTouchDevice();
+  const SlideTransition = (props: SlideProps) => <Slide {...props} direction={isMobile ? 'up' : 'left'} />;
 
   return (
-    <Modal
+    <CustomSnackbar
       open={open}
-      handleClose={handleClose}
-      title={headerJSX}
-      customStyle="max-w-[400px]"
-      mobileCentered
-      headerDivider={false}
-      contentClassName="px-6 pb-6 md:px-12"
+      onClose={handleClose}
+      TransitionComponent={SlideTransition}
+      containerClassName="flex-nowrap !items-start max-w-[400px]"
+      contentClassName="md:!items-start"
+      icon={<FeaturedIconOutlined iconName="check-circle" size="md" theme="success" />}
+      anchorOrigin={isMobile ? { vertical: 'bottom', horizontal: 'center' } : { vertical: 'top', horizontal: 'right' }}
     >
-      <div className="text-sm leading-5 md:px-6 text-Gray-light-mode-700">
-        <span className="font-semibold text-Brand-700">{claimantName} </span>
-        will be notified of your response and will have the opportunity to review the information you provided.
+      <div className="flex flex-col gap-4 pb-2 px-2 md:py-2 md:px-0">
+        <div className="flex flex-col md:flex-row gap-2">
+          <div className="flex flex-col text-sm font-semibold text-Gray-light-mode-900">
+            Response submitted successfully
+            <span className="font-normal text-sm leading-5 text-Gray-light-mode-500">
+              Thank you for submitting your response to the dispute (Dispute ID #{disputeId}). Your response has been
+              successfully recorded and will be reviewed by the assigned jurors.
+            </span>
+          </div>
+        </div>
+        <div className="text-sm leading-5 text-Gray-light-mode-700">
+          <span className="font-semibold text-Brand-700">{claimantName} </span>
+          will be notified of your response and will have the opportunity to review the information you provided.
+        </div>
       </div>
-    </Modal>
+    </CustomSnackbar>
   );
 };
 

--- a/src/Nowruz/modules/general/components/Snackbar/index.tsx
+++ b/src/Nowruz/modules/general/components/Snackbar/index.tsx
@@ -8,10 +8,10 @@ const CustomSnackbar: React.FC<CustomSnackbarProps> = ({
   open,
   onClose,
   anchorOrigin = { vertical: 'top', horizontal: 'center' },
-  text,
+  children,
   icon,
   containerClassName = '',
-  textClassName = '',
+  contentClassName = '',
   ...props
 }) => {
   return (
@@ -19,9 +19,9 @@ const CustomSnackbar: React.FC<CustomSnackbarProps> = ({
       <SnackbarContent
         className={`bg-Base-White flex items-start md:items-center py-0 px-2 rounded-xl min-w-[320px] ${containerClassName}`}
         message={
-          <div className="flex flex-col items-start gap-2 md:flex-row md:items-center">
+          <div className={`flex flex-col items-start gap-2 md:flex-row md:items-center ${contentClassName}`}>
             {icon}
-            <span className={`text-sm font-semibold text-Gray-light-mode-900 ${textClassName}`}>{text}</span>
+            {children}
           </div>
         }
         action={[

--- a/src/Nowruz/modules/general/components/Snackbar/index.types.ts
+++ b/src/Nowruz/modules/general/components/Snackbar/index.types.ts
@@ -1,8 +1,7 @@
 import { SnackbarProps } from '@mui/material';
 
 export interface CustomSnackbarProps extends SnackbarProps {
-  text: string;
   icon?: React.ReactNode;
   containerClassName?: string;
-  textClassName?: string;
+  contentClassName?: string;
 }

--- a/src/Nowruz/pages/feeds/index.tsx
+++ b/src/Nowruz/pages/feeds/index.tsx
@@ -63,8 +63,11 @@ export const Feeds = () => {
         onClose={() => setShowSnackbar({ create: false, edit: false })}
         autoHideDuration={6000}
         icon={<FeaturedIconOutlined iconName="check-circle" size="md" theme="primary" />}
-        text={`Post successfully ${showSnackbar.create ? 'published' : 'updated'}`}
-      />
+      >
+        <span className="text-sm font-semibold text-Gray-light-mode-900">
+          Post successfully {showSnackbar.create ? 'published' : 'updated'}
+        </span>
+      </CustomSnackbar>
     </FeedsProvider>
   );
 };


### PR DESCRIPTION
**REFACTOR:**
- [x] `<Snackbar />` component recieve `children` instead of `text` according to new design
- [x] `<Snackbar />` in feeds page for showing `post published successfully` with new refactoring

**FIX:**
- [x] use new `<Snackbar />` in `success initiate dispute` instead of `Modal`
- [x] use new `<Snackbar />` in `success respond dispute` instead of `Modal`

TODO:
- [x] transition and animation on `<Snackbar />` component