### PR TITLE
TAS-2168/Fix-Timeline-Dispute-Detail

### DIFF
--- a/src/Nowruz/modules/dispute/components/timelineItem/index.tsx
+++ b/src/Nowruz/modules/dispute/components/timelineItem/index.tsx
@@ -32,7 +32,9 @@ export const TimelineItem: React.FC<TimelineItemProps> = ({
     <div className="w-full flex gap-3">
       <div className="flex flex-col gap-1 w-fit pb-1">
         <Avatar type={type as UserType} img={profileImage} />
-        <div className="w-1/2 flex-1  border-r-2 border-l-0 border-y-0 border-solid border-Gray-light-mode-200" />
+        {displayDivider && (
+          <div className="w-1/2 flex-1  border-r-2 border-l-0 border-y-0 border-solid border-Gray-light-mode-200" />
+        )}
       </div>
       <div className="flex flex-col gap-3 flex-1 pb-8">
         <div className="flex flex-col h-12 max-h-12 min-h-12 justify-center">


### PR DESCRIPTION
**FIX:**
 - [x] removed the last divider in the timeline of dispute detail via `displayDivider` prop