### PR TITLE
TAS-2192-TAS-2249/OP-Preferences-Culture

### DIFF
--- a/public/icons/circle-tick-white.svg
+++ b/public/icons/circle-tick-white.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#E6EDED" style="fill:#E6EDED;fill:color(display-p3 0.9020 0.9294 0.9294);fill-opacity:1;"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17.096 7.39004L9.93602 14.3L8.03602 12.27C7.68602 11.94 7.13602 11.92 6.73602 12.2C6.34602 12.49 6.23602 13 6.47602 13.41L8.72602 17.07C8.94602 17.41 9.32601 17.62 9.75601 17.62C10.166 17.62 10.556 17.41 10.776 17.07C11.136 16.6 18.006 8.41004 18.006 8.41004C18.906 7.49004 17.816 6.68004 17.096 7.38004V7.39004Z" fill="#004A46" style="fill:#004A46;fill:color(display-p3 0.0000 0.2902 0.2745);fill-opacity:1;"/>
+</svg>

--- a/src/constants/PREFERENCES.ts
+++ b/src/constants/PREFERENCES.ts
@@ -1,0 +1,77 @@
+export const PREFERENCES_TOGGLES = [
+  {
+    key: 'HIRING',
+    title: 'Hiring',
+    subtitle: 'You are currently actively hiring professionals.',
+    value: 'OFF',
+  },
+  {
+    key: 'CRYPTO_PAYMENT_AVAILABLE',
+    title: 'Crypto payment available',
+    subtitle: 'Do you offer payment in crypto?',
+    value: 'OFF',
+  },
+];
+
+export const PREFERENCES_CULTURE_QUESTIONS = [
+  {
+    key: 'RISK_TAKING_VS_RISK_AVERSE',
+    title: 'Risk-Taking vs. Risk-Averse',
+    subtitle: 'Embracing Uncertainty vs. Prioritizing Safety',
+    answers: [
+      { label: 'Strongly embraces uncertainty', value: 'STRONG_HIGH' },
+      { label: 'Moderately embraces uncertainty', value: 'MODERATE_HIGH' },
+      { label: 'Neutral', value: 'NEUTRAL' },
+      { label: 'Moderately prioritizes safety', value: 'MODERATE_LOW' },
+      { label: 'Strongly prioritizes safety', value: 'STRONG_LOW' },
+      { label: 'Prefer not say', value: 'PREFER_NOT_SAY' },
+    ],
+    value: '',
+    description: '',
+  },
+  {
+    key: 'RESULTS_DRIVEN_VS_PROCESS_ORIENTED',
+    title: 'Results-Driven vs. Process-Oriented',
+    subtitle: 'Outcome Focus vs. Methodical Approach',
+    answers: [
+      { label: 'Strongly outcome-focused', value: 'STRONG_HIGH' },
+      { label: 'Moderately outcome-focused', value: 'MODERATE_HIGH' },
+      { label: 'Neutral', value: 'NEUTRAL' },
+      { label: 'Moderately process-oriented', value: 'MODERATE_LOW' },
+      { label: 'Strongly process-oriented', value: 'STRONG_LOW' },
+      { label: 'Prefer not say', value: 'PREFER_NOT_SAY' },
+    ],
+    value: '',
+    description: '',
+  },
+  {
+    key: 'AUTONOMY_VS_STRUCTURED_GUIDANCE',
+    title: 'Autonomy vs. Structured Guidance',
+    subtitle: 'Self-Directed Freedom vs. Supported Directions',
+    answers: [
+      { label: 'Strongly self-directed', value: 'STRONG_HIGH' },
+      { label: 'Moderately self-directed', value: 'MODERATE_HIGH' },
+      { label: 'Neutral', value: 'NEUTRAL' },
+      { label: 'Moderately needs directions', value: 'MODERATE_LOW' },
+      { label: 'Strongly needs directions', value: 'STRONG_LOW' },
+      { label: 'Prefer not say', value: 'PREFER_NOT_SAY' },
+    ],
+    value: '',
+    description: '',
+  },
+  {
+    key: 'HONEST_FEEDBACK_VS_AVOID_CONFLICT',
+    title: 'Honest Feedback vs Avoid Conflict',
+    subtitle: 'Directness in Communication vs. Maintaining Harmony',
+    answers: [
+      { label: 'Strongly direct in communication', value: 'STRONG_HIGH' },
+      { label: 'Moderately direct in communication', value: 'MODERATE_HIGH' },
+      { label: 'Neutral', value: 'NEUTRAL' },
+      { label: 'Moderately prefers maintaining harmony', value: 'MODERATE_LOW' },
+      { label: 'Strongly prefers maintaining harmony', value: 'STRONG_LOW' },
+      { label: 'Prefer not say', value: 'PREFER_NOT_SAY' },
+    ],
+    value: '',
+    description: '',
+  },
+];

--- a/src/core/api/users/users.api.ts
+++ b/src/core/api/users/users.api.ts
@@ -19,6 +19,7 @@ import {
   UserProfile,
   EducationsReq,
   Education,
+  Preference,
 } from './users.types';
 
 export async function profile(): Promise<User> {
@@ -132,4 +133,12 @@ export async function userApplicants(params: FilterReq): Promise<ApplicantsRes> 
 
 export async function recommendedJobs(username: string, params?: PaginateReq): Promise<JobsRes> {
   return (await get<JobsRes>(`user/${username}/recommend/jobs`, { params })).data;
+}
+
+export async function preferences(): Promise<Preference[]> {
+  return (await get<Preference[]>('preferences', {})).data;
+}
+
+export async function updatePreferences(payload: { preferences: Preference[] }): Promise<Preference[]> {
+  return (await post<Preference[]>('preferences', payload)).data;
 }

--- a/src/core/api/users/users.types.ts
+++ b/src/core/api/users/users.types.ts
@@ -192,3 +192,19 @@ export interface Credential {
   created_at: Date;
   updated_at: Date;
 }
+
+export type PreferenceValue =
+  | 'ON'
+  | 'OFF'
+  | 'STRONG_HIGH'
+  | 'MODERATE_HIGH'
+  | 'NEUTRAL'
+  | 'MODERATE_LOW'
+  | 'STRONG_LOW'
+  | 'PREFER_NOT_SAY';
+
+export interface Preference {
+  title: string;
+  value: PreferenceValue;
+  description?: string;
+}

--- a/src/core/router/router.blueprint.tsx
+++ b/src/core/router/router.blueprint.tsx
@@ -115,6 +115,7 @@ export const blueprint: RouteObject[] = [
                           limit: 2,
                           identity_id: organization.id,
                         });
+
                         return {
                           organization,
                           orgJobs,

--- a/src/modules/Preferences/OrgPreferences/CultureAccordions/index.module.scss
+++ b/src/modules/Preferences/OrgPreferences/CultureAccordions/index.module.scss
@@ -1,0 +1,21 @@
+@import 'src/styles/constants/_primitives.scss';
+
+.section {
+    padding: 1.5rem 0;
+    display: flex;
+    flex-direction: column;
+
+    &__title {
+        font-weight: 600;
+        color: $color-grey-900;
+        font-size: 1.125rem;
+        line-height: 1.75rem;
+    }
+
+    &__subtitle {
+        font-weight: 400;
+        color: $color-grey-600;
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+    }
+}

--- a/src/modules/Preferences/OrgPreferences/CultureAccordions/index.tsx
+++ b/src/modules/Preferences/OrgPreferences/CultureAccordions/index.tsx
@@ -1,0 +1,72 @@
+import { Divider, Typography } from '@mui/material';
+import Accordion from 'src/modules/general/components/Accordion';
+import { Button } from 'src/modules/general/components/Button';
+import { Input } from 'src/modules/general/components/input/input';
+import { RadioGroup } from 'src/modules/general/components/RadioGroup';
+
+import css from './index.module.scss';
+import { CultureAccordionsProps } from './index.types';
+import { useCultureAccordions } from './useCultureAccordions';
+
+const CultureAccordions: React.FC<CultureAccordionsProps> = ({ preferences }) => {
+  const {
+    data: { currentCulturePreferences, letterCounts, errors },
+    operations: { onSelectCultureValues, handleCultureDescriptions, onSubmit },
+  } = useCultureAccordions(preferences);
+
+  return (
+    <form key="culture" className="flex flex-col" onSubmit={onSubmit}>
+      <div className={css['section']}>
+        <span className={css['section__title']}>Our Culture</span>
+        <span className={css['section__subtitle']}>
+          Highlight the distinct aspects of your organizational environment and values, from risk-taking to innovation
+          and teamwork, to attract talent that resonates with and thrives in your cultural landscape.
+        </span>
+      </div>
+      {currentCulturePreferences.map(culture => (
+        <Accordion
+          key={culture.key}
+          title={culture.title}
+          subtitle={culture.subtitle}
+          expand
+          hasBorder={false}
+          contentClassName="flex flex-col !pt-0 gap-6"
+        >
+          <div className="border border-solid border-Gray-light-mode-200 rounded-default !p-4">
+            <RadioGroup
+              items={culture.answers}
+              contentClassName="!font-normal !text-Gray-light-mode-600"
+              selectedItem={{ label: culture.title, value: culture.value }}
+              onChange={option => onSelectCultureValues(culture.key, option.value.toString())}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Input
+              id="description"
+              label=""
+              name={culture.key}
+              value={culture.description}
+              onChange={e => handleCultureDescriptions(culture.key, e.target.value)}
+              multiline
+              customHeight="180px"
+              placeholder="Enter a description..."
+              fullWidth
+              errors={errors?.[culture.key] ? [errors[culture.key]] : undefined}
+            />
+            <Typography variant="caption" className="text-Gray-light-mode-600 mr-0 ml-auto">
+              {`${letterCounts?.[culture.key] ?? 0}/160`}
+            </Typography>
+          </div>
+        </Accordion>
+      ))}
+      <Divider />
+      <div className="py-6 self-end">
+        <Button variant="contained" color="primary" type="submit" disabled={!!Object.keys(errors).length}>
+          Save
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default CultureAccordions;

--- a/src/modules/Preferences/OrgPreferences/CultureAccordions/index.types.ts
+++ b/src/modules/Preferences/OrgPreferences/CultureAccordions/index.types.ts
@@ -1,0 +1,14 @@
+import { Preference } from 'src/core/api';
+
+export interface CultureAccordionsProps {
+  preferences: Preference[];
+}
+
+export type CultureType = {
+  key: string;
+  title: string;
+  subtitle: string;
+  value: string;
+  answers: { label: string; value: string }[];
+  description?: string;
+};

--- a/src/modules/Preferences/OrgPreferences/CultureAccordions/useCultureAccordions.tsx
+++ b/src/modules/Preferences/OrgPreferences/CultureAccordions/useCultureAccordions.tsx
@@ -1,0 +1,70 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+import { PREFERENCES_CULTURE_QUESTIONS } from 'src/constants/PREFERENCES';
+import { Preference, PreferenceValue, updatePreferences } from 'src/core/api';
+import { removedEmptyProps } from 'src/core/utils';
+
+import { CultureType } from './index.types';
+
+export const useCultureAccordions = (preferences: Preference[]) => {
+  const limitDescription = 160;
+  const [currentCulturePreferences, setCurrentCulturePreferences] =
+    useState<CultureType[]>(PREFERENCES_CULTURE_QUESTIONS);
+  const [letterCounts, setLetterCounts] = useState<Record<string, number> | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const mapToCulturePreferences = (newPreferences: Preference[]) => {
+    return PREFERENCES_CULTURE_QUESTIONS.map(culture => {
+      const hasCulturePreferences = newPreferences.find(preference => preference.title === culture.key);
+      return hasCulturePreferences
+        ? { ...culture, value: hasCulturePreferences.value, description: hasCulturePreferences.description }
+        : culture;
+    });
+  };
+
+  useEffect(() => {
+    setCurrentCulturePreferences(mapToCulturePreferences(preferences));
+  }, [preferences]);
+
+  const onSelectCultureValues = (name: string, value: string) => {
+    const updatedCulturePreferences = currentCulturePreferences.map(culture =>
+      culture.key === name ? { ...culture, value: value as PreferenceValue } : culture,
+    );
+    setCurrentCulturePreferences(updatedCulturePreferences);
+  };
+
+  const handleCultureDescriptions = (name: string, value: string) => {
+    const updatedCulturePreferences = currentCulturePreferences.map(culture =>
+      culture.key === name ? { ...culture, description: value } : culture,
+    );
+    setCurrentCulturePreferences(updatedCulturePreferences);
+    setLetterCounts({ ...letterCounts, [name]: value.length });
+    if (value.length > limitDescription) setErrors({ ...errors, [name]: 'Too Long' });
+    else setErrors(removedEmptyProps({ ...errors, [name]: '' }) as Record<string, string>);
+  };
+
+  const onSubmit = async (e: ChangeEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const preferences: Preference[] = currentCulturePreferences
+      .map(culture => {
+        //FIXME: API issue
+        const payload = removedEmptyProps({
+          title: culture.key,
+          value: culture.value as PreferenceValue,
+          description: culture.description,
+        });
+        return payload as Preference;
+      })
+      .filter(culture => culture.value);
+
+    try {
+      await updatePreferences({ preferences });
+    } catch (e) {
+      console.log('error in updating culture preferences', e);
+    }
+  };
+
+  return {
+    data: { currentCulturePreferences, letterCounts, errors },
+    operations: { onSelectCultureValues, handleCultureDescriptions, onSubmit },
+  };
+};

--- a/src/modules/Preferences/OrgPreferences/Toggles/index.module.scss
+++ b/src/modules/Preferences/OrgPreferences/Toggles/index.module.scss
@@ -1,0 +1,11 @@
+.toggle {
+    @apply flex gap-8 py-6;
+
+    &__header {
+        @apply flex flex-col font-semibold leading-6 text-Gray-light-mode-900 w-[280px];
+    }
+
+    &__subheader {
+        @apply text-sm font-normal leading-6 text-Gray-light-mode-600;
+    }
+}

--- a/src/modules/Preferences/OrgPreferences/Toggles/index.tsx
+++ b/src/modules/Preferences/OrgPreferences/Toggles/index.tsx
@@ -1,0 +1,43 @@
+import { Divider } from '@mui/material';
+import { Button } from 'src/modules/general/components/Button';
+import { ToggleButton } from 'src/modules/general/components/toggleButton';
+
+import css from './index.module.scss';
+import { TogglesProps } from './index.types';
+import { useToggles } from './useToggles';
+
+const Toggles: React.FC<TogglesProps> = ({ preferences }) => {
+  const {
+    data: { currentTogglePreferences },
+    operations: { handleCheckToggles, onSubmit },
+  } = useToggles(preferences);
+
+  return (
+    <form className="pb-2" onSubmit={onSubmit}>
+      {currentTogglePreferences.map((toggle, index) => (
+        <>
+          <div key={toggle.key} className={css['toggle']}>
+            <div className={css['toggle__header']}>
+              {toggle.title}
+              <span className={css['toggle__subheader']}>{toggle.subtitle}</span>
+            </div>
+            <ToggleButton
+              name={toggle.key}
+              checked={toggle.value === 'ON'}
+              size="small"
+              onChange={e => handleCheckToggles(toggle.key, e.target.checked)}
+            />
+          </div>
+          {index === 0 && <Divider />}
+        </>
+      ))}
+      <div className="flex justify-end">
+        <Button variant="contained" color="primary" type="submit">
+          Save
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default Toggles;

--- a/src/modules/Preferences/OrgPreferences/Toggles/index.types.ts
+++ b/src/modules/Preferences/OrgPreferences/Toggles/index.types.ts
@@ -1,0 +1,12 @@
+import { Preference } from 'src/core/api';
+
+export interface TogglesProps {
+  preferences: Preference[];
+}
+
+export type ToggleType = {
+  key: string;
+  title: string;
+  subtitle: string;
+  value: string;
+};

--- a/src/modules/Preferences/OrgPreferences/Toggles/useToggles.tsx
+++ b/src/modules/Preferences/OrgPreferences/Toggles/useToggles.tsx
@@ -1,0 +1,45 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+import { PREFERENCES_TOGGLES } from 'src/constants/PREFERENCES';
+import { Preference, PreferenceValue, updatePreferences } from 'src/core/api';
+
+import { ToggleType } from './index.types';
+
+export const useToggles = (preferences: Preference[]) => {
+  const [currentTogglePreferences, setCurrentTogglePreferences] = useState<ToggleType[]>(PREFERENCES_TOGGLES);
+  const mapToTogglePreferences = (newPreferences: Preference[]) => {
+    return PREFERENCES_TOGGLES.map(toggle => {
+      const hasTogglePreferences = newPreferences.find(preference => preference.title === toggle.key);
+      return hasTogglePreferences ? { ...toggle, value: hasTogglePreferences.value } : toggle;
+    });
+  };
+
+  useEffect(() => {
+    setCurrentTogglePreferences(mapToTogglePreferences(preferences));
+  }, [preferences]);
+
+  const handleCheckToggles = (name: string, checked: boolean) => {
+    const updatedTogglePreferences = currentTogglePreferences.map(toggle =>
+      toggle.key === name ? { ...toggle, value: checked ? 'ON' : 'OFF' } : toggle,
+    );
+    setCurrentTogglePreferences(updatedTogglePreferences);
+  };
+
+  const onSubmit = async (e: ChangeEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const preferences: Preference[] = currentTogglePreferences.map(toggle => ({
+      title: toggle.key,
+      value: toggle.value as PreferenceValue,
+    }));
+
+    try {
+      await updatePreferences({ preferences });
+    } catch (e) {
+      console.log('error in updating toggle preferences', e);
+    }
+  };
+
+  return {
+    data: { currentTogglePreferences },
+    operations: { handleCheckToggles, onSubmit },
+  };
+};

--- a/src/modules/Preferences/OrgPreferences/index.module.scss
+++ b/src/modules/Preferences/OrgPreferences/index.module.scss
@@ -1,0 +1,23 @@
+@import 'src/styles/constants/_primitives.scss';
+
+.header {
+    margin-bottom: 1.25rem;
+    gap: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    &__title {
+        font-weight: 600;
+        color: $color-grey-900;
+        font-size: 1.25rem;
+        line-height: 1.875rem;
+    }
+
+    &__subtitle {
+        font-weight: 400;
+        color: $color-grey-600;
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+    }
+}

--- a/src/modules/Preferences/OrgPreferences/index.tsx
+++ b/src/modules/Preferences/OrgPreferences/index.tsx
@@ -1,0 +1,24 @@
+import { Divider } from '@mui/material';
+import CultureAccordions from 'src/modules/Preferences/OrgPreferences/CultureAccordions';
+
+import css from './index.module.scss';
+import Toggles from './Toggles';
+import { useOrgPreferences } from './useOrgPreferences';
+
+const OrgPreferences = () => {
+  const { preferences } = useOrgPreferences();
+
+  return (
+    <>
+      <div className={css['header']}>
+        <h1 className={css['header__title']}>Preferences</h1>
+        <h2 className={css['header__subtitle']}>Add your details to help us match you with the perfect talent</h2>
+      </div>
+      <Divider />
+      <Toggles preferences={preferences} />
+      <CultureAccordions preferences={preferences} />
+    </>
+  );
+};
+
+export default OrgPreferences;

--- a/src/modules/Preferences/OrgPreferences/useOrgPreferences.tsx
+++ b/src/modules/Preferences/OrgPreferences/useOrgPreferences.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { Preference, preferences } from 'src/core/api';
+
+export const useOrgPreferences = () => {
+  const [currentPreferences, setCurrentPreferences] = useState<Preference[]>([]);
+
+  useEffect(() => {
+    const getPreferences = async () => {
+      const res = await preferences();
+      setCurrentPreferences(res);
+    };
+    getPreferences();
+  }, []);
+
+  return { preferences: currentPreferences };
+};

--- a/src/modules/general/components/RadioGroup/RadioGroup.types.ts
+++ b/src/modules/general/components/RadioGroup/RadioGroup.types.ts
@@ -19,4 +19,5 @@ export interface RadioGroupProps {
   preselectIndex?: number;
   defaultValue?: string | number;
   labelClassName?: string;
+  contentClassName?: string;
 }

--- a/src/modules/general/components/RadioGroup/index.tsx
+++ b/src/modules/general/components/RadioGroup/index.tsx
@@ -18,6 +18,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   onChange,
   defaultValue,
   labelClassName = '',
+  contentClassName = '',
 }) => {
   const [selectedIndex, setSelectedIndex] = useState<null | number>();
   return (
@@ -47,7 +48,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
                   }}
                 />
               }
-              label={<span className={css.optionsText}>{item.label}</span>}
+              label={<span className={`${css.optionsText} ${contentClassName}`}>{item.label}</span>}
               sx={{ width: 'fit-content' }}
             />
             {(selectedIndex === index || item.value === defaultValue) && item.children}

--- a/src/modules/userProfile/components/about/Culture/index.tsx
+++ b/src/modules/userProfile/components/about/Culture/index.tsx
@@ -1,0 +1,40 @@
+import { IconButton } from 'src/modules/general/components/iconButton';
+import variables from 'src/styles/constants/_exports.module.scss';
+
+import { CultureProps } from './index.types';
+
+const Culture: React.FC<CultureProps> = ({ items, onOpenPreferences }) => {
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center text-lg text-Gray-light-mode-900 font-semibold">
+        Culture
+        <IconButton
+          iconName="pencil-01"
+          iconColor={variables.color_grey_600}
+          iconSize={20}
+          size="medium"
+          customStyle="flex items-center justify-center mr-0 ml-auto"
+          onClick={onOpenPreferences}
+        />
+      </div>
+      <div className="flex flex-col gap-4">
+        {items.map(item => (
+          <div key={item.title} className="flex gap-3">
+            <img src="/icons/circle-tick-white.svg" width={24} height={24} alt="culture" />
+            <div>
+              <div className="leading-6 text-Gray-light-mode-600">
+                <span className="font-medium text-Gray-light-mode-900">{item.title}: </span>
+                {item.value}
+              </div>
+              {item?.description && (
+                <span className="leading-6 text-Gray-light-mode-600 break-all">{item.description}</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Culture;

--- a/src/modules/userProfile/components/about/Culture/index.types.ts
+++ b/src/modules/userProfile/components/about/Culture/index.types.ts
@@ -1,0 +1,8 @@
+export interface CultureProps {
+  items: {
+    title: string;
+    value: string;
+    description?: string;
+  }[];
+  onOpenPreferences: () => void;
+}

--- a/src/modules/userProfile/components/about/index.tsx
+++ b/src/modules/userProfile/components/about/index.tsx
@@ -2,6 +2,7 @@ import { Divider } from '@mui/material';
 import { KYCModal } from 'src/modules/refer/KYC';
 
 import { Certificates } from './certificate/certificates';
+import Culture from './Culture';
 import { Educations } from './education/educations';
 import { Experiences } from './experience/experience';
 import { Recommendation } from './recommendaion/recommendation';
@@ -10,8 +11,9 @@ import { Summary } from './summary';
 import { useAbout } from './useAbout';
 import { MainInfo } from '../mainInfo';
 
-export const About = () => {
-  const { connectUrl, handleOpenVerifyModal, identityType, openVerifyModal, setOpenVerifyModal } = useAbout();
+export const About = ({ onOpenPreferences }) => {
+  const { connectUrl, culturePreferences, handleOpenVerifyModal, identityType, openVerifyModal, setOpenVerifyModal } =
+    useAbout();
 
   return (
     <div className="flex flex-col gap-8">
@@ -20,6 +22,12 @@ export const About = () => {
       </div>
       <Summary />
       <Divider />
+      {identityType === 'organizations' && (
+        <>
+          <Culture items={culturePreferences} onOpenPreferences={onOpenPreferences} />
+          <Divider />
+        </>
+      )}
       {identityType === 'users' && (
         <>
           <Skills />

--- a/src/modules/userProfile/components/about/useAbout.tsx
+++ b/src/modules/userProfile/components/about/useAbout.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { PREFERENCES_CULTURE_QUESTIONS } from 'src/constants/PREFERENCES';
+import { Preference, preferences, PreferenceValue } from 'src/core/api';
 import { verifyAction } from 'src/modules/refer/referUtils';
 import { RootState } from 'src/store';
 
@@ -7,6 +9,34 @@ export const useAbout = () => {
   const identityType = useSelector<RootState, 'users' | 'organizations'>(state => {
     return state.profile.type;
   });
+  const [currentPreference, setCurrentPreference] = useState<{ culture: Preference[]; value: Preference[] }>({
+    culture: [],
+    value: [],
+  });
+
+  const mapToCulturePreferences = (newPreferences: Preference[]) => {
+    return newPreferences
+      .filter(preference => PREFERENCES_CULTURE_QUESTIONS.some(culture => culture.key === preference.title))
+      .map(preference => {
+        const culture = PREFERENCES_CULTURE_QUESTIONS.find(culture => culture.key === preference.title);
+        const answer = culture?.answers.find(answer => answer.value === preference.value);
+        return {
+          title: culture?.title || preference.title,
+          value: (answer?.label || preference.value) as PreferenceValue,
+          description: preference.description || '',
+        };
+      });
+  };
+
+  useEffect(() => {
+    const getPreferences = async () => {
+      const res = await preferences();
+      //TODO: Marjan, please use this state for setting value on `about` section
+      setCurrentPreference({ ...currentPreference, culture: mapToCulturePreferences(res) });
+    };
+    getPreferences();
+  }, []);
+
   const [openVerifyModal, setOpenVerifyModal] = useState(false);
   const [connectUrl, setConnectUrl] = useState<string>('');
 
@@ -15,5 +45,12 @@ export const useAbout = () => {
     setOpenVerifyModal(true);
   };
 
-  return { connectUrl, handleOpenVerifyModal, identityType, openVerifyModal, setOpenVerifyModal };
+  return {
+    connectUrl,
+    culturePreferences: currentPreference.culture,
+    handleOpenVerifyModal,
+    identityType,
+    openVerifyModal,
+    setOpenVerifyModal,
+  };
 };

--- a/src/pages/orgProfile/useOrgProfile.tsx
+++ b/src/pages/orgProfile/useOrgProfile.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useLoaderData, useLocation } from 'react-router-dom';
 import { JobsRes, OrganizationProfile } from 'src/core/api';
 import Badge from 'src/modules/general/components/Badge';
+import OrgPreferences from 'src/modules/Preferences/OrgPreferences';
 import { About } from 'src/modules/userProfile/components/about';
 import { OrganizationJobs } from 'src/modules/userProfile/components/jobs';
 import { setIdentity, setIdentityType } from 'src/store/reducers/profile.reducer';
@@ -24,7 +25,7 @@ export const useOrgProfile = () => {
   }, [location]);
 
   const tabs = [
-    { label: 'About', content: <About /> },
+    { label: 'About', content: <About onOpenPreferences={() => setActive(2)} /> },
     {
       label: (
         <>
@@ -34,6 +35,7 @@ export const useOrgProfile = () => {
       ),
       content: <OrganizationJobs />,
     },
+    { label: 'Preferences', content: <OrgPreferences /> },
   ];
 
   return { tabs, active };


### PR DESCRIPTION
**This PR includes three parts in the org Profile:**
- [x] toggles(`hiring` and `cypto ok`) in the `preferences` section
- [x] `cultures` in the in the `preferences` section
- [x] culture in the `about` section 

**Also some refactorings on:**
- [x] Accordion needs `subtitle` according to the new design
- [x] RadioGroup needs  `contentClassName` for customizing the radio's content according to the new design

**TODO:**
- [x] API preferences from BE
- [x] Culture on `About` from API
- [x] Final check
