### PR TITLE
TAS-2438/Refactoring-Horizontal-Tabs

### DIFF
--- a/src/modules/general/components/horizontalTabs/horizontalTabs.types.ts
+++ b/src/modules/general/components/horizontalTabs/horizontalTabs.types.ts
@@ -10,4 +10,5 @@ export interface HorizontalTabsProps {
   leftAligned?: boolean;
   containerCustomStyle?: string;
   activeIndex?: number;
+  onActiveIndex?: (index: number) => void;
 }

--- a/src/modules/general/components/horizontalTabs/index.tsx
+++ b/src/modules/general/components/horizontalTabs/index.tsx
@@ -1,21 +1,28 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import css from './horizontalTabs.module.scss';
 import { HorizontalTabsProps } from './horizontalTabs.types';
 
-export const HorizontalTabs: React.FC<HorizontalTabsProps> = props => {
-  const { tabs, leftAligned = true, containerCustomStyle, activeIndex = 0 } = props;
-
+export const HorizontalTabs: React.FC<HorizontalTabsProps> = ({
+  tabs,
+  leftAligned = true,
+  containerCustomStyle = '',
+  activeIndex = 0,
+  onActiveIndex,
+}) => {
   const [active, setActive] = useState(activeIndex);
-  const [content, setContent] = useState<ReactNode>();
 
   useEffect(() => {
     setActive(activeIndex);
   }, [activeIndex]);
 
-  useEffect(() => {
-    setContent(tabs[active].content);
-  }, [active, tabs]);
+  const handleTabClick = (index: number) => {
+    if (onActiveIndex) {
+      onActiveIndex(index);
+    } else {
+      setActive(index);
+    }
+  };
 
   return (
     <div className={`w-full h-full flex flex-col gap-8 ${containerCustomStyle}`}>
@@ -24,13 +31,13 @@ export const HorizontalTabs: React.FC<HorizontalTabsProps> = props => {
           <div
             key={`${tab.label}-${index.toString()}`}
             className={`${css.tab} ${index === active ? css.tabActive : ''} ${leftAligned ? '' : 'flex-1'}`}
-            onClick={() => setActive(index)}
+            onClick={() => handleTabClick(index)}
           >
             {tab.label}
           </div>
         ))}
       </div>
-      <div className="w-full h-full">{content}</div>
+      <div className="w-full h-full">{tabs[active]?.content}</div>
     </div>
   );
 };

--- a/src/pages/contribute/contributeCenter/index.tsx
+++ b/src/pages/contribute/contributeCenter/index.tsx
@@ -14,7 +14,7 @@ export const ContributeCenter = () => {
           <h2 className={css.subtitle}>Manage disputes here.</h2>
         </div>
       </div>
-      <HorizontalTabs tabs={tabs} activeIndex={0} />
+      <HorizontalTabs tabs={tabs} />
     </div>
   );
 };

--- a/src/pages/disputes/index.tsx
+++ b/src/pages/disputes/index.tsx
@@ -14,7 +14,7 @@ export const Disputes = () => {
           <h2 className={css.subtitle}>Manage your disputes here.</h2>
         </div>
       </div>
-      <HorizontalTabs tabs={tabs} activeIndex={0} />
+      <HorizontalTabs tabs={tabs} />
     </div>
   );
 };

--- a/src/pages/orgProfile/index.tsx
+++ b/src/pages/orgProfile/index.tsx
@@ -6,7 +6,7 @@ import css from './orgProfile.module.scss';
 import { useOrgProfile } from './useOrgProfile';
 
 export const OrgProfile = () => {
-  const { tabs, active } = useOrgProfile();
+  const { tabs, active, setActive } = useOrgProfile();
 
   return (
     <div className="w-full">
@@ -16,7 +16,7 @@ export const OrgProfile = () => {
           <MainInfo />
         </div>
         <div className={`${css.rightCol} w-full md:w-auto`}>
-          <HorizontalTabs tabs={tabs} activeIndex={active} />
+          <HorizontalTabs tabs={tabs} activeIndex={active} onActiveIndex={setActive} />
         </div>
       </div>
     </div>

--- a/src/pages/orgProfile/useOrgProfile.tsx
+++ b/src/pages/orgProfile/useOrgProfile.tsx
@@ -38,5 +38,5 @@ export const useOrgProfile = () => {
     { label: 'Preferences', content: <OrgPreferences /> },
   ];
 
-  return { tabs, active };
+  return { tabs, active, setActive };
 };


### PR DESCRIPTION
**REFACTOR:**
- [x] handle `controlled` and `uncontrolled` (control from inside/outside) `HorizontalTab` component
- [x] remove unnecessary prop (`activeIndex=0`) because as default it's `0`

**FIX**: 
- [x] Org Profile tabs need `onActiveIndex` to control the tab from outside (for changing to the `preference` tab via clicking on culture in the `about` tab)

TODO:
- [x] final check