### PR TITLE
TAS-101/Profile-Click-Chats

### DIFF
--- a/src/modules/chats/components/chatDetailItem/chatDetailItem.types.ts
+++ b/src/modules/chats/components/chatDetailItem/chatDetailItem.types.ts
@@ -5,5 +5,6 @@ export interface ChatDetailItemProps {
   senderAvatar?: string;
   senderName?: string;
   senderType?: 'users' | 'organizations';
+  onAvatarClick?: () => void;
   className?: string;
 }

--- a/src/modules/chats/components/chatDetailItem/index.tsx
+++ b/src/modules/chats/components/chatDetailItem/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { CurrentIdentity } from 'src/core/api';
 import { toRelativeTime } from 'src/core/relative-time';
@@ -13,7 +12,8 @@ export const ChatDetailItem: React.FC<ChatDetailItemProps> = ({
   senderAvatar,
   senderName,
   senderType,
-  className,
+  onAvatarClick,
+  className = '',
 }) => {
   const currentIdentity = useSelector<RootState, CurrentIdentity | undefined>(state => {
     return state.identity.entities.find(identity => identity.current);
@@ -34,7 +34,7 @@ export const ChatDetailItem: React.FC<ChatDetailItemProps> = ({
         </div>
       ) : (
         <div className="flex gap-3">
-          <Avatar img={senderAvatar} type={senderType || 'users'} size="40px" />
+          <Avatar img={senderAvatar} type={senderType || 'users'} size="40px" onClick={onAvatarClick} />
           <div className="flex flex-col gap-1.5 items-start">
             <div className="flex justify-between items-center gap-2">
               <span className="font-medium text-sm leading-5 text-Gray-light-mode-700">{senderName}</span>

--- a/src/modules/chats/components/chatDetails/index.tsx
+++ b/src/modules/chats/components/chatDetails/index.tsx
@@ -16,7 +16,7 @@ export const ChatDetails: React.FC<ChatDetailsProps> = ({
   newSocketMessage,
   setChats,
 }) => {
-  const { messages, onSend, account, loadMore, hasMore, page, setMessages } = useChatDetails(
+  const { messages, onSend, account, loadMore, hasMore, page, setMessages, onAvatarClick } = useChatDetails(
     selectedChatId,
     chats,
     setChats,
@@ -49,7 +49,7 @@ export const ChatDetails: React.FC<ChatDetailsProps> = ({
             handleClick={() => setOpenDetails(false)}
           />
         </div>
-        <AvatarLabelGroup account={account} customStyle="!p-0" />
+        <AvatarLabelGroup account={account} customStyle="!p-0" handleClick={onAvatarClick} />
       </div>
       <div id="chat-list-div" className="w-full p-4 md:p-8 flex-1 flex flex-col gap-6 overflow-y-auto">
         <InfiniteScroll

--- a/src/modules/chats/components/chatDetails/index.tsx
+++ b/src/modules/chats/components/chatDetails/index.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from 'react';
 import InfiniteScroll from 'react-infinite-scroller';
 import { SendMessage } from 'src/modules/chats/components/sendMessage';
 import { AvatarLabelGroup } from 'src/modules/general/components/avatarLabelGroup';
@@ -16,26 +15,12 @@ export const ChatDetails: React.FC<ChatDetailsProps> = ({
   newSocketMessage,
   setChats,
 }) => {
-  const { messages, onSend, account, loadMore, hasMore, page, setMessages, onAvatarClick } = useChatDetails(
+  const { sortedMessages, onSend, account, loadMore, hasMore, onAvatarClick } = useChatDetails(
     selectedChatId,
     chats,
     setChats,
+    newSocketMessage,
   );
-
-  const sorted = messages?.sort((a, b) => (new Date(a.created_at) > new Date(b.created_at) ? 1 : -1));
-
-  useEffect(() => {
-    if (page === 1) {
-      const messageBody = document.getElementById('chat-list-div');
-      if (messageBody) messageBody.scrollTop = messageBody.scrollHeight - messageBody.clientHeight;
-    }
-  }, [messages]);
-
-  useEffect(() => {
-    if (newSocketMessage && !messages.find(item => item.id === newSocketMessage.id)) {
-      setMessages([...messages, newSocketMessage]);
-    }
-  }, [newSocketMessage]);
 
   return (
     <div className="flex flex-col w-full h-full">
@@ -62,13 +47,14 @@ export const ChatDetails: React.FC<ChatDetailsProps> = ({
           isReverse
           className="flex-1"
         >
-          {sorted?.map((item, index) => (
+          {sortedMessages?.map(message => (
             <ChatDetailItem
-              key={item.id}
-              message={item}
+              key={message.id}
+              message={message}
               senderAvatar={account.img}
               senderType={account.type}
               senderName={account.name}
+              onAvatarClick={onAvatarClick}
             />
           ))}
         </InfiniteScroll>

--- a/src/modules/chats/components/chatDetails/useChatDetails.ts
+++ b/src/modules/chats/components/chatDetails/useChatDetails.ts
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import { Chat, CurrentIdentity, Message, OrgMeta, UserMeta, chatMessages, createChatMessage } from 'src/core/api';
-import { getIdentityMeta } from 'src/core/utils';
 import { RootState } from 'src/store';
 
 export const useChatDetails = (selectedChatId: string, chats: Chat[], setChats: (val: Chat[]) => void) => {
+  const navigate = useNavigate();
   const currentIdentity = useSelector<RootState, CurrentIdentity | undefined>(state => {
     return state.identity.entities.find(identity => identity.current);
   });
   const [messages, setMessages] = useState<Message[]>([]);
-
   const [page, setPage] = useState(1);
   const [hasMore, sethasMore] = useState(true);
   const chat = chats.find(item => item.id === selectedChatId);
@@ -64,5 +64,11 @@ export const useChatDetails = (selectedChatId: string, chats: Chat[], setChats: 
         }
       });
   };
-  return { messages, setMessages, onSend, account, loadMore, hasMore, page };
+
+  const onAvatarClick = () => {
+    if (account.type === 'users') navigate(`/profile/users/${account.username}/view`);
+    else navigate(`/profile/organizations/${account.username}/view`);
+  };
+
+  return { messages, setMessages, onSend, account, loadMore, hasMore, page, onAvatarClick };
 };

--- a/src/modules/chats/components/chatDetails/useChatDetails.ts
+++ b/src/modules/chats/components/chatDetails/useChatDetails.ts
@@ -4,14 +4,19 @@ import { useNavigate } from 'react-router-dom';
 import { Chat, CurrentIdentity, Message, OrgMeta, UserMeta, chatMessages, createChatMessage } from 'src/core/api';
 import { RootState } from 'src/store';
 
-export const useChatDetails = (selectedChatId: string, chats: Chat[], setChats: (val: Chat[]) => void) => {
+export const useChatDetails = (
+  selectedChatId: string,
+  chats: Chat[],
+  setChats: (val: Chat[]) => void,
+  newSocketMessage: Message | null,
+) => {
   const navigate = useNavigate();
   const currentIdentity = useSelector<RootState, CurrentIdentity | undefined>(state => {
     return state.identity.entities.find(identity => identity.current);
   });
   const [messages, setMessages] = useState<Message[]>([]);
   const [page, setPage] = useState(1);
-  const [hasMore, sethasMore] = useState(true);
+  const [hasMore, setHasMore] = useState(true);
   const chat = chats.find(item => item.id === selectedChatId);
   const participant = chat?.participants[0];
   const account = {
@@ -22,6 +27,34 @@ export const useChatDetails = (selectedChatId: string, chats: Chat[], setChats: 
     username:
       (participant?.identity_meta as UserMeta).username || (participant?.identity_meta as OrgMeta).shortname || '',
   };
+  const sortedMessages = messages?.sort((a, b) => (new Date(a.created_at) > new Date(b.created_at) ? 1 : -1));
+
+  useEffect(() => {
+    if (page === 1) {
+      const messageBody = document.getElementById('chat-list-div');
+      if (messageBody) messageBody.scrollTop = messageBody.scrollHeight - messageBody.clientHeight;
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    if (newSocketMessage && !messages.find(item => item.id === newSocketMessage.id)) {
+      setMessages([...messages, newSocketMessage]);
+    }
+  }, [newSocketMessage]);
+
+  useEffect(() => {
+    getMessages();
+  }, [selectedChatId]);
+
+  const getMessages = async () => {
+    if (selectedChatId) {
+      setPage(1);
+      setHasMore(true);
+      const res = await chatMessages(selectedChatId, { page: 1 });
+      setMessages(res.items);
+      updateUnreadCount();
+    }
+  };
 
   const updateUnreadCount = () => {
     const chatList = [...chats];
@@ -31,18 +64,6 @@ export const useChatDetails = (selectedChatId: string, chats: Chat[], setChats: 
     chatList[index].unread_count = unread.toString();
     setChats(chatList);
   };
-  const getMessages = async () => {
-    if (selectedChatId) {
-      setPage(1);
-      sethasMore(true);
-      const res = await chatMessages(selectedChatId, { page: 1 });
-      setMessages(res.items);
-      updateUnreadCount();
-    }
-  };
-  useEffect(() => {
-    getMessages();
-  }, [selectedChatId]);
 
   const onSend = async (message: string) => {
     if (!selectedChatId || !currentIdentity) return;
@@ -60,7 +81,7 @@ export const useChatDetails = (selectedChatId: string, chats: Chat[], setChats: 
           setPage(page + 1);
           updateUnreadCount();
         } else {
-          sethasMore(false);
+          setHasMore(false);
         }
       });
   };
@@ -70,5 +91,5 @@ export const useChatDetails = (selectedChatId: string, chats: Chat[], setChats: 
     else navigate(`/profile/organizations/${account.username}/view`);
   };
 
-  return { messages, setMessages, onSend, account, loadMore, hasMore, page, onAvatarClick };
+  return { sortedMessages, onSend, account, loadMore, hasMore, onAvatarClick };
 };

--- a/src/modules/chats/components/summaryCard/index.tsx
+++ b/src/modules/chats/components/summaryCard/index.tsx
@@ -1,5 +1,5 @@
 import { Typography } from '@mui/material';
-import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { OrgMeta, UserMeta } from 'src/core/api';
 import { toRelativeTime } from 'src/core/relative-time';
 import { getIdentityMeta } from 'src/core/utils';
@@ -11,23 +11,30 @@ import variables from 'src/styles/constants/_exports.module.scss';
 import { SummaryCardProps } from './summaryCard.types';
 
 export const SummaryCard: React.FC<SummaryCardProps> = ({ chat, handleSelect, isSelected }) => {
+  const navigate = useNavigate();
   const {
-    data: { copyProccessed },
+    data: { copyProcessed },
   } = useSeeMore(chat.last_message?.text || '', 50);
 
   const {
     profileImage,
     username,
+    usernameVal,
     type = 'users',
     name,
-  } = getIdentityMeta(chat.participants[0].identity_meta as UserMeta | OrgMeta);
-
+  } = getIdentityMeta(chat?.participants[0].identity_meta as UserMeta | OrgMeta);
   const account = {
-    id: chat.participants[0].identity_meta?.id || '',
+    id: chat?.participants[0].identity_meta?.id || '',
     img: profileImage,
     type,
     name,
     username,
+    usernameVal,
+  };
+
+  const onAvatarClick = () => {
+    if (account.type === 'users') navigate(`/profile/users/${account.usernameVal}/view`);
+    else navigate(`/profile/organizations/${account.usernameVal}/view`);
   };
 
   return (
@@ -42,7 +49,15 @@ export const SummaryCard: React.FC<SummaryCardProps> = ({ chat, handleSelect, is
             color={Number(chat.unread_count) ? variables.color_primary_600 : 'transparent'}
             shadow={false}
           />
-          <AvatarLabelGroup account={account} customStyle="!w-fit !p-0" />
+          <AvatarLabelGroup
+            account={account}
+            customStyle="!w-fit !p-0"
+            justAvatarClickable
+            handleClick={e => {
+              e?.stopPropagation();
+              onAvatarClick();
+            }}
+          />
         </div>
         <Typography variant="caption" color={variables.color_grey_600}>
           {toRelativeTime(chat.updated_at)}
@@ -50,7 +65,7 @@ export const SummaryCard: React.FC<SummaryCardProps> = ({ chat, handleSelect, is
       </div>
       <div className="pl-5">
         <Typography variant="caption" color={variables.color_grey_600}>
-          {copyProccessed}
+          {copyProcessed}
         </Typography>
       </div>
     </div>

--- a/src/modules/general/components/avatar/avatar.types.ts
+++ b/src/modules/general/components/avatar/avatar.types.ts
@@ -5,7 +5,7 @@ export interface AvatarProps extends CSSProperties {
   type: 'organizations' | 'users';
   img?: string;
   iconName?: string;
-  onClick?: () => void;
+  onClick?: (e?: React.MouseEvent<HTMLDivElement>) => void;
   customStyle?: string;
   iconCustomStyle?: string;
   badge?: { image: string; color: string; width?: string; height?: string };

--- a/src/modules/general/components/avatarLabelGroup/avatarLabelGroup.types.ts
+++ b/src/modules/general/components/avatarLabelGroup/avatarLabelGroup.types.ts
@@ -2,8 +2,9 @@ import { AccountItem } from '../avatarDropDown/avatarDropDown.types';
 
 export interface AvatarLabelGroupProps {
   account: AccountItem;
-  customStyle?: string;
-  handleClick?: () => void;
   avatarSize?: string;
   removeFull?: boolean;
+  justAvatarClickable?: boolean;
+  handleClick?: (e?: React.MouseEvent<HTMLDivElement>) => void;
+  customStyle?: string;
 }

--- a/src/modules/general/components/avatarLabelGroup/index.tsx
+++ b/src/modules/general/components/avatarLabelGroup/index.tsx
@@ -5,16 +5,27 @@ import variables from 'src/styles/constants/_exports.module.scss';
 
 import { AvatarLabelGroupProps } from './avatarLabelGroup.types';
 
-export const AvatarLabelGroup: React.FC<AvatarLabelGroupProps> = props => {
-  const { account, customStyle, handleClick, avatarSize, removeFull = false } = props;
+export const AvatarLabelGroup: React.FC<AvatarLabelGroupProps> = ({
+  account,
+  avatarSize,
+  removeFull = false,
+  justAvatarClickable = false,
+  handleClick,
+  customStyle = '',
+}) => {
   const nonFull = removeFull ? '' : 'w-full';
 
   return (
     <div
-      className={`${nonFull} h-fit flex flex-row gap-3 py-3 px-4 ${customStyle} ${handleClick && 'cursor-pointer'}`}
-      onClick={handleClick}
+      className={`${nonFull} h-fit flex flex-row gap-3 py-3 px-4 ${customStyle} ${handleClick && !justAvatarClickable && 'cursor-pointer'}`}
+      onClick={e => !justAvatarClickable && handleClick?.(e)}
     >
-      <Avatar img={account.img} type={account.type} size={avatarSize || '40px'} />
+      <Avatar
+        img={account.img}
+        type={account.type}
+        size={avatarSize || '40px'}
+        onClick={e => justAvatarClickable && handleClick?.(e)}
+      />
       <div className="flex flex-col">
         <Typography variant="subtitle2" color={variables.color_grey_900}>
           {account.name}

--- a/src/modules/general/utils/index.ts
+++ b/src/modules/general/utils/index.ts
@@ -1,16 +1,20 @@
 import { useEffect, useState } from 'react';
 import { isTouchDevice } from 'src/core/device-type-detector';
 
-export const useSeeMore = (copy: string, expectedLenght?: number) => {
+export const useSeeMore = (copy: string, expectedLength?: number) => {
   const [seeMore, setSeeMore] = useState(false);
-  const [copyProccessed, setCopyProccessed] = useState(copy);
+  const [copyProcessed, setCopyProcessed] = useState(copy);
+
+  useEffect(() => {
+    truncateString();
+  }, [copy]);
 
   const truncateString = () => {
     const len = copy?.length || 0;
-    const maxLen = expectedLenght || (isTouchDevice() ? 160 : 360);
+    const maxLen = expectedLength || (isTouchDevice() ? 160 : 360);
 
     if (copy && len <= maxLen) {
-      setCopyProccessed(copy);
+      setCopyProcessed(copy);
       setSeeMore(false);
       return;
     }
@@ -21,22 +25,18 @@ export const useSeeMore = (copy: string, expectedLenght?: number) => {
         const idx = truncated.lastIndexOf(' ');
         truncated = truncated.slice(0, idx);
       }
-      setCopyProccessed(truncated.concat('...'));
+      setCopyProcessed(truncated.concat('...'));
       setSeeMore(true);
     }
   };
 
   const handleSeeMore = () => {
-    setCopyProccessed(copy);
+    setCopyProcessed(copy);
     setSeeMore(false);
   };
 
-  useEffect(() => {
-    truncateString();
-  }, [copy]);
-
   return {
-    data: { seeMore, copyProccessed },
+    data: { seeMore, copyProcessed },
     operations: { handleSeeMore },
   };
 };

--- a/src/modules/userProfile/components/about/summary.tsx
+++ b/src/modules/userProfile/components/about/summary.tsx
@@ -18,7 +18,7 @@ export const Summary = () => {
   });
 
   const {
-    data: { seeMore, copyProccessed },
+    data: { seeMore, copyProcessed },
     operations: { handleSeeMore },
   } = useSeeMore(identity?.mission ?? '');
 
@@ -44,7 +44,7 @@ export const Summary = () => {
         </div>
         <div className={css.mission}>
           <p>
-            {copyProccessed}
+            {copyProcessed}
             {seeMore && (
               <span className={css.seeMoreBtn} onClick={handleSeeMore}>
                 see more

--- a/src/pages/jobs/detail/applicants/applicant.tsx
+++ b/src/pages/jobs/detail/applicants/applicant.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Applicant, Media } from 'src/core/api';
+import { Applicant } from 'src/core/api';
 import { Avatar } from 'src/modules/general/components/avatar/avatar';
 import { Button } from 'src/modules/general/components/Button';
 import { useSeeMore } from 'src/modules/general/utils';
@@ -20,7 +19,7 @@ export const ApplicantDetails: React.FC<ApplicantDetailsProps> = ({
   closeDetails,
 }) => {
   const {
-    data: { seeMore, copyProccessed },
+    data: { seeMore, copyProcessed },
     operations: { handleSeeMore },
   } = useSeeMore(applicant?.cover_letter ?? '');
 
@@ -69,7 +68,7 @@ export const ApplicantDetails: React.FC<ApplicantDetailsProps> = ({
           <div className="flex flex-col gap-1">
             <p className="text-sm font-medium text-Gray-light-mode-700">Cover letter</p>
             <p className="leading-6 break-words whitespace-pre-wrap">
-              {copyProccessed}
+              {copyProcessed}
               {seeMore && (
                 <span className="cursor-pointer" onClick={handleSeeMore}>
                   See more


### PR DESCRIPTION
**This branch is related to adding a profile click on the chats section on:**
- [x] at the top of the chats section
- [x] in the sidebar of chats
- [x]  inside chats

**Also,** includes:
- [x] added the `event` optional parameter for the `onClick` prop to `<Avatar />`
- [x] added the `event` optional parameter for the `handleClick` prop to `<AvatarLableGroup />` 
- [x] added a `justAvatarClickable` prop to `<AvatarLableGroup />` for clicking on avatar or whole container
- [x] refactored and fixed type issues `useSeeMore` and files that used this hook