### PR TITLE
TAS-246/Dispute-Designer-Feedback

### DIFF
--- a/src/modules/Disputes/DisputesList/index.tsx
+++ b/src/modules/Disputes/DisputesList/index.tsx
@@ -23,7 +23,7 @@ const DisputesList: React.FC<DisputesListProps> = ({ list, mode }) => {
         id: 'code',
         header: translate('dispute-id'),
         accessorKey: 'code',
-        cell: ({ getValue }: { getValue: Getter<string> }) => `#${getValue()}`,
+        cell: ({ getValue }: { getValue: Getter<string> }) => getValue(),
       },
       {
         id: mode === 'submitted' ? 'respondent' : 'claimant',

--- a/src/modules/contract/components/initiateDisputeModal/index.tsx
+++ b/src/modules/contract/components/initiateDisputeModal/index.tsx
@@ -102,7 +102,7 @@ const InitiateDisputeModal: React.FC<InitiateDisputeModalProps> = ({ open, handl
         </span>
       </div>
       <FileUploaderMultiple
-        fileTypes={['PDF', 'DOC', 'DOCX', 'PNG', 'JPG', 'GIF', 'MOV or MP4']}
+        fileTypes={['PDF', 'DOC', 'DOCX', 'PNG', 'JPG', 'GIF', 'MOV', 'MP4']}
         maxFileNumbers={10}
         maxSize={10}
         uploaded={files}

--- a/src/modules/contract/components/initiateDisputeModal/useInitiateDisputeModal.tsx
+++ b/src/modules/contract/components/initiateDisputeModal/useInitiateDisputeModal.tsx
@@ -53,7 +53,7 @@ export const useInitiateDisputeModal = (
 
   const initializeValues = () => {
     const initialVal = {
-      category: { value: '', label: '' },
+      category: undefined,
       title: '',
       description: '',
       evidences: [],

--- a/src/modules/dispute/components/contributorDashboard/index.tsx
+++ b/src/modules/dispute/components/contributorDashboard/index.tsx
@@ -147,19 +147,19 @@ export const ContributorDashboard: React.FC<ContributorDashboardProps> = ({ newl
         footerDivider={false}
         customStyle="md:max-w-[480px]"
       >
-        <div className="px-4 py-5 md:p-6 text-Gray-light-mode-600 font-normal text-sm leading-5">
+        <div className="flex flex-col gap-5 px-4 py-5 md:p-6 text-Gray-light-mode-600 font-normal text-sm leading-5">
           <p>
             We value your contributions and would be sad to see you go! If you need a break, you might consider pausing
             your participation instead.
           </p>
           <p>By pausing your contributor status, you will:</p>
-          <ul className="list-disc my-5 ml-6">
+          <ul className="list-disc ml-6">
             <li>Temporarily stop receiving new task notifications</li>
             <li>Retain your contributor status</li>
             <li>Have the flexibility to resume your participation whenever you&apos;re ready</li>
           </ul>
           <p>If you still wish to opt out, please keep in mind that:</p>
-          <ul className="list-disc mt-5 ml-6">
+          <ul className="list-disc ml-6">
             <li>You will be removed from the Contributor Program and stop receiving all task notifications</li>
             <li>You will lose your contributor status</li>
             <li>You&apos;ll need to go through the opt-in process again if you decide to rejoin in the future</li>

--- a/src/modules/dispute/components/timelineItem/index.tsx
+++ b/src/modules/dispute/components/timelineItem/index.tsx
@@ -22,12 +22,11 @@ export const TimelineItem: React.FC<TimelineItemProps> = ({
   disputeDirection,
   respondent,
 }) => {
-  const { name, type, profileImage, myEvent, getEventTitle, getFileIcon } = useTimelineItem(
+  const { name, type, profileImage, myEvent, title, getFileIcon } = useTimelineItem(
     event,
     disputeDirection,
     respondent,
   );
-  const title = getEventTitle();
   return (
     <div className="w-full flex gap-3">
       <div className="flex flex-col gap-1 w-fit pb-1">

--- a/src/modules/dispute/components/timelineItem/useTimelineItem.tsx
+++ b/src/modules/dispute/components/timelineItem/useTimelineItem.tsx
@@ -20,29 +20,23 @@ export const useTimelineItem = (
     { type: 'png', icon: '/icons/file-png.svg' },
   ];
 
-  const getEventTitle = () => {
-    switch (event.type) {
-      case 'MESSAGE':
-        return {
-          text: `Filed a dispute against ${disputeDirection === 'received' ? 'you' : ''}`,
-          supportingText: disputeDirection === 'received' ? '' : respondent.meta.name,
-        };
-      case 'RESPONSE':
-        return {
-          text: '',
-          supportingText: '',
-        };
-      case 'WITHDRAW':
-        return {
-          text: 'Withdrew this dispite',
-          supportingText: '',
-        };
-      case 'VOTE':
-        return {
-          text: '',
-          supportingText: '',
-        };
-    }
+  const title = {
+    MESSAGE: {
+      text: `Filed a dispute against ${disputeDirection === 'received' ? 'you' : ''}`,
+      supportingText: disputeDirection === 'received' ? '' : respondent.meta.name,
+    },
+    RESPONSE: {
+      text: 'Submitted a response',
+      supportingText: '',
+    },
+    WITHDRAW: {
+      text: 'Withdrew this dispute',
+      supportingText: '',
+    },
+    VOTE: {
+      text: '',
+      supportingText: '',
+    },
   };
 
   const getFileIcon = (fileUrl: string) => {
@@ -51,5 +45,5 @@ export const useTimelineItem = (
     return { name: fileName, icon: fileIcon };
   };
 
-  return { name, type, profileImage, myEvent, getEventTitle, getFileIcon };
+  return { name, type, profileImage, myEvent, title: title[event.type], getFileIcon };
 };

--- a/src/modules/general/components/fileUploaderMultiple/useFileUploaderMultiple.tsx
+++ b/src/modules/general/components/fileUploaderMultiple/useFileUploaderMultiple.tsx
@@ -45,8 +45,8 @@ export const useFileUploader = (
   };
 
   const getSubtitle = () => {
-    let text = fileTypes.slice(0, fileTypes.length - 1).join();
-    text = `${text} or ${fileTypes[fileTypes.length - 1]} (max. ${maxSize}mb)`;
+    let text = fileTypes.slice(0, fileTypes.length - 1).join(', ');
+    text = `${text} or ${fileTypes[fileTypes.length - 1]} (max. ${maxSize}MB)`;
     return text;
   };
 

--- a/src/modules/layout/containers/notifications/useNotifications.tsx
+++ b/src/modules/layout/containers/notifications/useNotifications.tsx
@@ -21,7 +21,7 @@ export const useNotifications = (handleClose: () => void) => {
     const mapRoute = {
       DISPUTE_INITIATED: {
         hasSubText: true,
-        linkButton: { label: 'View Details', href: `/disputes/${item.ref_id}` },
+        linkButton: { label: 'View Details', href: `/disputes/${item.ref_id}#received` },
       },
       DISPUTE_NEW_RESPONSE: {
         hasSubText: true,

--- a/src/pages/disputes/disputeDetail/useDisputeDetail.tsx
+++ b/src/pages/disputes/disputeDetail/useDisputeDetail.tsx
@@ -303,7 +303,7 @@ export const useDisputeDetail = () => {
   const handleBack = () => {
     const path = location.pathname.includes('contributor')
       ? `/${(currentIdentity?.meta as UserMeta).username}/contribute/center`
-      : '/disputes';
+      : `/disputes${location.hash}`;
     navigate(path);
   };
 

--- a/src/pages/disputes/index.tsx
+++ b/src/pages/disputes/index.tsx
@@ -5,7 +5,7 @@ import css from './disputes.module.scss';
 import { useDisputes } from './useDisputes';
 
 export const Disputes = () => {
-  const { tabs } = useDisputes();
+  const { tabs, activeTabIndex } = useDisputes();
 
   return (
     <div className={css.container}>
@@ -15,7 +15,7 @@ export const Disputes = () => {
           <h2 className={css.subtitle}>{translate('dispute-subtitle')}</h2>
         </div>
       </div>
-      <HorizontalTabs tabs={tabs} />
+      <HorizontalTabs tabs={tabs} activeIndex={activeTabIndex} />
     </div>
   );
 };

--- a/src/pages/disputes/useDisputes.tsx
+++ b/src/pages/disputes/useDisputes.tsx
@@ -1,9 +1,10 @@
-import { useLoaderData } from 'react-router-dom';
+import { useLoaderData, useLocation } from 'react-router-dom';
 import { DisputesRes } from 'src/core/api';
 import { translate } from 'src/core/utils';
 import DisputesList from 'src/modules/Disputes/DisputesList';
 
 export const useDisputes = () => {
+  const { hash } = useLocation();
   const { submittedDisputes, receivedDisputes } = useLoaderData() as {
     submittedDisputes: DisputesRes;
     receivedDisputes: DisputesRes;
@@ -12,6 +13,10 @@ export const useDisputes = () => {
     { label: translate('dispute-submitted'), content: <DisputesList list={submittedDisputes} mode="submitted" /> },
     { label: translate('dispute-received'), content: <DisputesList list={receivedDisputes} mode="received" /> },
   ];
+  const activeTabIndex = {
+    '#submitted': 0,
+    '#received': 1,
+  };
 
-  return { tabs };
+  return { tabs, activeTabIndex: activeTabIndex[hash] || 0 };
 };


### PR DESCRIPTION
**This branch is related to some issues on dispute resolution,** includes:
- [x] fixed dispute category `placeholder` on `initiate dispute modal`
- [x] fixed text format and space between file types for uploading documents on `initiate dispute modal` 
- [x] removed `#` from dispute id in disputes list
- [x] fixed navigation to the `received` tab when clicking on `Back to disputes` (after clicking on `view detail` of initiated dispute notification and moving to dispute detail)
- [x] `Submitted a response` on the dispute detail page
- [x] fixed style issue between paragraphs on `leave contributor program modal` 

