### PR TITLE
TAS-3023/Update-Languages-On-Profile

### DIFF
--- a/src/core/api/users/users.types.ts
+++ b/src/core/api/users/users.types.ts
@@ -35,6 +35,7 @@ export interface UpdateProfileReq {
   certificates?: string[];
   goals?: string;
   educations?: string[];
+  languages?: LanguageReq[];
 }
 
 export interface UpdateWalletReq {
@@ -139,7 +140,7 @@ export interface UserProfile extends User {
 
 export interface Language extends LanguageReq {
   id: string;
-  created_at: Date;
+  created_at?: Date;
 }
 
 export interface Experience extends ExperienceReq {

--- a/src/modules/userProfile/containers/editInfo/useEditInfo.tsx
+++ b/src/modules/userProfile/containers/editInfo/useEditInfo.tsx
@@ -210,6 +210,7 @@ export const useEditInfo = (handleClose: () => void) => {
       city: getValues().city.label,
       country: getValues().country,
       social_causes: getValues().socialCauses?.map(item => item.value),
+      languages: languages.map(language => ({ name: language.name, level: language.level })),
     };
 
     const promises: Promise<any>[] = [];

--- a/src/store/thunks/profile.thunks.ts
+++ b/src/store/thunks/profile.thunks.ts
@@ -20,6 +20,7 @@ export const updateUserProfile = createAsyncThunk('profile/updateUserProfile', a
   if (user.social_causes) reqParam.social_causes = user.social_causes;
   if (user.skills) reqParam.skills = user.skills;
   if (user.mobile_country_code) reqParam.mobile_country_code = user.mobile_country_code;
+  if (user.languages) reqParam.languages = user.languages;
 
   const profile = await updateProfile(reqParam);
   return profile;


### PR DESCRIPTION
**FIX:**
- [x] updating languages needs refreshing the profile page to show updated values


TODO:
- [ ] BE should allow `languages` as parameters for `/update/profile` endpoint
- [ ] final check
