### PR TITLE
TAS-3475/Feeds-Notifications

### DIFF
--- a/src/modules/layout/containers/notifications/useNotifications.tsx
+++ b/src/modules/layout/containers/notifications/useNotifications.tsx
@@ -75,10 +75,10 @@ export const useNotifications = (handleClose: () => void) => {
         path = `/profile/${notifIdentityType}/${username}/view`;
         break;
       case 'COMMENT_LIKE':
-        path = `/feeds/${notifRefId}`;
+        path = '/feeds';
         break;
       case 'POST_LIKE':
-        path = `/feeds/${notifRefId}`;
+        path = '/feeds';
         break;
       case 'CHAT':
         path = `/chats/contacts/${notifRefId}`;
@@ -90,7 +90,7 @@ export const useNotifications = (handleClose: () => void) => {
         path = '';
         break;
       case 'COMMENT':
-        path = `/feeds/${notifRefId}`;
+        path = '/feeds';
         break;
       case 'APPLICATION':
         path = `/jobs/created/${notifRefId}`;


### PR DESCRIPTION
**FIX:**
- [x] navigated the user to the `/feeds` page when clicking on `Comment`, `Post like`, `Comment like` notifications 